### PR TITLE
Add daily backup script for data folder and .env

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Asset Management Backup Script
+# Backs up data folder and .env to Google Drive
+
+# Configuration
+SOURCE_DIR="/Volumes/Untitled/projects/asset-management"
+BACKUP_BASE="$HOME/Google Drive/My Drive/asset_management_backup_files"
+DATETIME=$(date +"%Y-%m-%d_%H-%M-%S")
+BACKUP_DIR="$BACKUP_BASE/$DATETIME"
+
+# Create backup directory
+mkdir -p "$BACKUP_DIR"
+
+# Copy data folder
+if [ -d "$SOURCE_DIR/data" ]; then
+    cp -r "$SOURCE_DIR/data" "$BACKUP_DIR/"
+    echo "Backed up: data folder"
+else
+    echo "Warning: data folder not found"
+fi
+
+# Copy .env file
+if [ -f "$SOURCE_DIR/.env" ]; then
+    cp "$SOURCE_DIR/.env" "$BACKUP_DIR/"
+    echo "Backed up: .env file"
+else
+    echo "Warning: .env file not found"
+fi
+
+echo "Backup completed: $BACKUP_DIR"
+
+# Optional: Remove backups older than 30 days
+find "$BACKUP_BASE" -maxdepth 1 -type d -mtime +30 -exec rm -rf {} \; 2>/dev/null
+
+echo "Cleanup: Removed backups older than 30 days"


### PR DESCRIPTION
## Summary
- Adds a backup script that copies the `data/` folder and `.env` file to Google Drive
- Creates timestamped backup folders (e.g., `2026-02-02_21-06-04`)
- Auto-removes backups older than 30 days

## Usage
```bash
# Run manually
./backup.sh

# Schedule with launchd (macOS) - runs daily at 2 AM
# Plist goes in ~/Library/LaunchAgents/
```

## Backup location
`~/Google Drive/My Drive/asset_management_backup_files/`

## Test plan
- [x] Script executes without errors
- [x] Creates backup folder with correct timestamp format
- [x] Copies data folder and .env file

🤖 Generated with [Claude Code](https://claude.com/claude-code)