### PR TITLE
Add couple expense share widget to dashboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -1545,7 +1545,7 @@
                         <div class="person-name" id="coupleShareUserName">You</div>
                         <div class="person-amount" id="coupleShareUserAmount">$0.00</div>
                         <div class="person-bar-container">
-                            <div class="person-bar" id="coupleShareUserBar" style="width: 0%"></div>
+                            <div class="person-bar" id="coupleShareUserBar" style="width: 0%" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Your expense share"></div>
                         </div>
                         <div class="person-share" id="coupleShareUserPercent">0% of total</div>
                     </div>
@@ -1553,7 +1553,7 @@
                         <div class="person-name" id="coupleSharePartnerName">Partner</div>
                         <div class="person-amount" id="coupleSharePartnerAmount">$0.00</div>
                         <div class="person-bar-container">
-                            <div class="person-bar" id="coupleSharePartnerBar" style="width: 0%"></div>
+                            <div class="person-bar" id="coupleSharePartnerBar" style="width: 0%" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-label="Partner's expense share"></div>
                         </div>
                         <div class="person-share" id="coupleSharePartnerPercent">0% of total</div>
                     </div>

--- a/js/app.js
+++ b/js/app.js
@@ -787,8 +787,14 @@ function updateCoupleShare(entriesToShow) {
     document.getElementById('coupleSharePartnerAmount').textContent = `$${partnerExpenses.toFixed(2)}`;
 
     // Update bars
-    document.getElementById('coupleShareUserBar').style.width = `${userPercent}%`;
-    document.getElementById('coupleSharePartnerBar').style.width = `${partnerPercent}%`;
+    const userBar = document.getElementById('coupleShareUserBar');
+    const partnerBar = document.getElementById('coupleSharePartnerBar');
+    userBar.style.width = `${userPercent}%`;
+    userBar.setAttribute('aria-valuenow', Math.round(userPercent));
+    userBar.setAttribute('aria-label', `${currentUser.username || 'Your'} expense share`);
+    partnerBar.style.width = `${partnerPercent}%`;
+    partnerBar.setAttribute('aria-valuenow', Math.round(partnerPercent));
+    partnerBar.setAttribute('aria-label', `${currentUser.partnerUsername || 'Partner'} expense share`);
 
     // Update percentages
     document.getElementById('coupleShareUserPercent').textContent = `${userPercent.toFixed(1)}% of total`;
@@ -801,10 +807,12 @@ function updateCoupleShare(entriesToShow) {
     if (totalExpenses === 0) {
         settlementEl.textContent = 'No expenses recorded';
         settlementEl.className = 'settlement-amount settlement-settled';
+        settlementEl.style.color = '';
         directionEl.textContent = '';
     } else if (Math.abs(userExpenses - partnerExpenses) < 0.01) {
         settlementEl.textContent = 'All settled up!';
         settlementEl.className = 'settlement-amount settlement-settled';
+        settlementEl.style.color = '';
         directionEl.textContent = 'Both paid equally';
     } else {
         const overpayer = userExpenses > partnerExpenses ? currentUser.username : currentUser.partnerUsername;


### PR DESCRIPTION
## Summary
- Adds an **Expense Share** section visible only in the Combined (Couple) view mode
- Shows each partner's total expenses, percentage share with visual progress bars, and a settlement card indicating who owes whom and how much (based on a 50/50 split)
- Fully respects active filters (date range, type, category) and updates in real-time

## Test plan
- [ ] Log in as a user with a linked partner
- [ ] Switch to Combined (Couple) view — verify the Expense Share section appears
- [ ] Switch back to Individual view — verify the section is hidden
- [ ] Add couple expenses from both partners and verify amounts, percentages, and settlement update correctly
- [ ] Apply date/category filters and verify the widget recalculates accordingly
- [ ] Test on mobile viewport — cards should stack vertically
- [ ] Log in as a user without a partner — verify the section never appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)