### PR TITLE
Fix mobile safe area spacing and modal scrolling

### DIFF
--- a/index.html
+++ b/index.html
@@ -108,7 +108,7 @@
             padding: 0;
             padding-top: env(safe-area-inset-top, 0px);
             background: var(--color-bg-base);
-            min-height: 100vh;
+            min-height: calc(100vh - env(safe-area-inset-top, 0px));
             position: relative;
         }
 
@@ -129,7 +129,7 @@
             padding: 1.5rem 2.5rem;
             border-bottom: 1px solid var(--color-border);
             position: sticky;
-            top: 0;
+            top: env(safe-area-inset-top, 0px);
             z-index: 100;
             backdrop-filter: blur(20px);
             -webkit-backdrop-filter: blur(20px);
@@ -682,6 +682,8 @@
             border: 1px solid var(--color-border);
             position: relative;
             animation: fadeInUp 0.3s ease;
+            max-height: 85vh;
+            overflow-y: auto;
         }
 
         .modal-content h2 {
@@ -715,11 +717,6 @@
         }
 
         @media (max-width: 768px) {
-            .modal-content {
-                max-height: 85vh;
-                overflow-y: auto;
-            }
-
             .header-buttons {
                 margin-left: 0;
                 width: 100%;
@@ -807,8 +804,6 @@
             .modal-content {
                 padding: 1.5rem;
                 width: 95%;
-                max-height: 80vh;
-                overflow-y: auto;
             }
         }
 


### PR DESCRIPTION
## Summary
- Add `viewport-fit=cover` to viewport meta tag to enable safe area insets on iOS
- Use `env(safe-area-inset-top)` to add top spacing on the main page and all modal panels, preventing overlap with the phone status bar
- Make modal content scrollable on small screens so buttons at the bottom of panels (e.g. admin panel) are accessible

## Test plan
- [ ] Open the app on a smartphone (or simulator) and verify the main page content doesn't overlap the status bar
- [ ] Open modal panels (admin, bulk upload, entry form) and verify they are spaced below the status bar
- [ ] On a small screen, open the admin panel and verify it scrolls to reach bottom buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)