### PR TITLE
Redirect unauthenticated users to login page

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1492,9 +1492,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 hasPartner = !!currentUser.partnerId;
                 updateUIForRole();
                 updateUIForPartner();
+            } else {
+                window.location.href = '/login.html';
             }
         } catch (error) {
             console.error('Error fetching user:', error);
+            window.location.href = '/login.html';
         }
     }
 


### PR DESCRIPTION
## Summary
- Unauthenticated visitors to `index.html` are now redirected to `/login.html`
- Previously, they could see the empty dashboard shell (no data was exposed, but the UI was visible)
- Redirect triggers when `/api/user` returns non-ok or on network error

## Test plan
- [ ] Open `index.html` in a private/incognito window (no session) — should redirect to login
- [ ] Log in normally — dashboard should load as expected
- [ ] Log out — should redirect to login and not be able to go back to dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)