### PR TITLE
Fix Sonnet/Opus failures with Claude Code OAuth (#53)

### DIFF
--- a/server.js
+++ b/server.js
@@ -257,6 +257,31 @@ function createAnthropicClient({ authToken, apiKey }) {
     return new Anthropic({ apiKey });
 }
 
+/**
+ * Build the `system` parameter for an Anthropic messages.create() call.
+ *
+ * When using a Claude Code OAuth token (anthropic-beta: oauth-2025-04-20),
+ * Anthropic requires the first system block to identify the request as
+ * coming from Claude Code. Without this, non-Haiku models (Sonnet, Opus)
+ * reject the call — often surfacing as a misleading "credit balance" /
+ * "quota exceeded" error rather than a proper auth failure. Haiku 4.5 is
+ * more permissive and still answers, which is why it appeared to be the
+ * only working model. See:
+ *   https://github.com/openclaw/openclaw/blob/main/src/agents/anthropic-transport-stream.ts
+ *
+ * For API-key auth this prefix is unnecessary — return the prompt as a
+ * plain string to keep the wire format identical to before.
+ */
+function buildAnthropicSystemPrompt({ authToken }, systemPrompt) {
+    if (authToken) {
+        return [
+            { type: 'text', text: "You are Claude Code, Anthropic's official CLI for Claude." },
+            ...(systemPrompt ? [{ type: 'text', text: systemPrompt }] : [])
+        ];
+    }
+    return systemPrompt;
+}
+
 // ── GitHub Copilot client ───────────────────────────────────────────
 //
 // GitHub Copilot exposes an OpenAI-compatible chat completions API at
@@ -3581,11 +3606,12 @@ app.post('/api/ai/chat', requireAuth, chatRateLimiter, asyncHandler(async (req, 
             }
 
             let currentMessages = anthropicMessages;
+            const anthropicSystem = buildAnthropicSystemPrompt(anthropicAuth, chatSystemPrompt);
             for (let i = 0; i < maxIterations; i++) {
                 const response = await anthropicClient.messages.create({
                     model: resolveModel(req.user, 'anthropic', 'chat'),
                     max_tokens: 4096,
-                    system: chatSystemPrompt,
+                    system: anthropicSystem,
                     messages: currentMessages,
                     tools: anthropicToolDeclarations,
                     temperature: 0.7
@@ -3935,7 +3961,8 @@ ${text}`;
                 const response = await anthropicClient.messages.create({
                     model: resolveModel(req.user, 'anthropic', 'pdf'),
                     max_tokens: 4096,
-                    system: 'You are a financial document parser. Respond with valid JSON only — no markdown, no code fences, no commentary.',
+                    system: buildAnthropicSystemPrompt(anthropicAuth,
+                        'You are a financial document parser. Respond with valid JSON only — no markdown, no code fences, no commentary.'),
                     messages: [{ role: 'user', content: prompt }],
                     temperature: 0.2
                 });


### PR DESCRIPTION
Closes #53.

## Root cause

When using a Claude Code OAuth token (the `anthropic-beta: oauth-2025-04-20` flow added in v2.5.0), Anthropic's API requires the **first system block** to identify the request as coming from Claude Code:

> "You are Claude Code, Anthropic's official CLI for Claude."

Without this prefix, non-Haiku models (Sonnet 4.x, Opus 4.x) reject the request — and the failure surfaces as a misleading **`credit_balance_too_low` / quota-exceeded** error rather than an auth error. Haiku 4.5 happens to be more permissive and still answers, which is exactly the symptom reported ("only Haiku 4.5 works; Sonnet/Opus look quota-blocked").

## Reference

OpenClaw's Anthropic transport gates the same prefix on `isOAuthToken`:
[`src/agents/anthropic-transport-stream.ts:627-641`](https://github.com/openclaw/openclaw/blob/608cfd36f5b0f758f803eed6f43b3b3292326c5b/src/agents/anthropic-transport-stream.ts#L627-L641)

```ts
if (isOAuthToken) {
  params.system = [
    { type: 'text', text: "You are Claude Code, Anthropic's official CLI for Claude." },
    ...(context.systemPrompt ? [{ type: 'text', text: context.systemPrompt }] : [])
  ];
}
```

## Changes

- Add `buildAnthropicSystemPrompt({authToken}, systemPrompt)` helper next to the existing `createAnthropicClient()`. When the auth is an OAuth token, it returns a **system-blocks array** prefixed with the Claude Code identifier; otherwise it returns the prompt as a plain string so the API-key wire format is byte-for-byte unchanged.
- Wire the helper into both Anthropic call sites:
  - `/api/ai/chat` (financial-advisor chat)
  - `/api/process-pdf` (PDF expense extraction)
- `/api/ai/models` is unaffected (`client.models.list()` carries no system prompt).

## Verification

- `node --check server.js` passes.
- API-key path: when `authToken` is null the helper returns the same string previously passed, so existing API-key users see no change.
- OAuth path: requests against Sonnet 4.6 / Opus 4.7 / etc. should now succeed (and continue to bill against the user's Claude Code subscription).

## Notes for the issue

- Default model IDs (`claude-sonnet-4-6`) were verified as current and do not need bumping. Users can already pick Opus 4.7 (or any other available model) in **Settings → AI Model**, populated dynamically from `/api/ai/models`.
- No DB migration, no env-var changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>