### PR TITLE
Show which AI tools were used in chat replies (#57)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2036,6 +2036,71 @@
         }
         .chat-confirm-btn:hover { opacity: 0.9; }
         .chat-confirm-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+        .chat-tools-panel {
+            align-self: flex-start;
+            max-width: 90%;
+            margin: 0.25rem 0 0.1rem;
+            padding: 0.4rem 0.6rem;
+            background: rgba(99, 102, 241, 0.08);
+            border: 1px solid rgba(99, 102, 241, 0.25);
+            border-radius: 0.5rem;
+            font-size: 0.72rem;
+            color: var(--color-text-secondary, #a0a0b0);
+        }
+        .chat-tools-summary {
+            cursor: pointer;
+            font-weight: 600;
+            color: #818cf8;
+            list-style: none;
+            display: flex;
+            align-items: center;
+            gap: 0.35rem;
+        }
+        .chat-tools-summary::-webkit-details-marker { display: none; }
+        .chat-tools-summary::after {
+            content: '▸';
+            margin-left: auto;
+            transition: transform 0.15s;
+        }
+        .chat-tools-panel[open] .chat-tools-summary::after { transform: rotate(90deg); }
+        .chat-tools-icon { display: inline-block; }
+        .chat-tools-list {
+            list-style: none;
+            padding: 0.4rem 0 0;
+            margin: 0;
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+        }
+        .chat-tools-item {
+            display: flex;
+            flex-wrap: wrap;
+            align-items: baseline;
+            gap: 0.3rem;
+            padding: 0.2rem 0.35rem;
+            border-left: 2px solid #818cf8;
+            background: rgba(255, 255, 255, 0.02);
+            border-radius: 0.25rem;
+        }
+        .chat-tools-item--error { border-left-color: #ef4444; }
+        .chat-tools-item--pending { border-left-color: #f59e0b; }
+        .chat-tools-name {
+            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+            color: #c7d2fe;
+            font-weight: 600;
+        }
+        .chat-tools-args {
+            color: var(--color-text-secondary, #a0a0b0);
+            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+            font-size: 0.68rem;
+        }
+        .chat-tools-result { color: #86efac; }
+        .chat-tools-error { color: #fca5a5; }
+        .chat-tools-duration {
+            margin-left: auto;
+            color: #6b7280;
+            font-size: 0.65rem;
+        }
         .chat-cancel-btn {
             flex: 1;
             padding: 0.45rem 0.75rem;

--- a/index.html
+++ b/index.html
@@ -2057,6 +2057,7 @@
             gap: 0.35rem;
         }
         .chat-tools-summary::-webkit-details-marker { display: none; }
+        .chat-tools-summary::marker { content: ''; }
         .chat-tools-summary::after {
             content: '▸';
             margin-left: auto;

--- a/js/chat.js
+++ b/js/chat.js
@@ -291,6 +291,9 @@
             }
 
             const data = await res.json();
+            if (data.toolsUsed && data.toolsUsed.length > 0) {
+                renderToolsUsedPanel(data.toolsUsed);
+            }
             appendMessage('assistant', data.reply || t('chat.errorGeneric'));
             if (data.pendingEdits && data.pendingEdits.length > 0) {
                 renderConfirmationCard(data.pendingEdits);
@@ -424,6 +427,51 @@
         msg.className = 'chat-confirm-result chat-confirm-result--' + type;
         msg.textContent = text;
         card.replaceWith(msg);
+        scrollToBottom();
+    }
+
+    function formatToolArgs(args) {
+        if (!args || typeof args !== 'object') return '';
+        const parts = [];
+        for (const [k, v] of Object.entries(args)) {
+            let val;
+            if (Array.isArray(v)) val = v.join(', ');
+            else val = String(v);
+            if (val.length > 40) val = val.slice(0, 37) + '…';
+            parts.push(`${k}: ${val}`);
+        }
+        return parts.join(' · ');
+    }
+
+    function renderToolsUsedPanel(toolsUsed) {
+        const panel = document.createElement('details');
+        panel.className = 'chat-tools-panel';
+        const count = toolsUsed.length;
+        const summaryEl = document.createElement('summary');
+        summaryEl.className = 'chat-tools-summary';
+        const label = count === 1 ? t('chat.toolsUsedOne') : t('chat.toolsUsedMany', { count });
+        summaryEl.innerHTML = '<span class="chat-tools-icon">🔧</span> ' + escapeHtml(label);
+        panel.appendChild(summaryEl);
+
+        const list = document.createElement('ul');
+        list.className = 'chat-tools-list';
+        for (const inv of toolsUsed) {
+            const li = document.createElement('li');
+            li.className = 'chat-tools-item chat-tools-item--' + (inv.status || 'success');
+            const argsStr = formatToolArgs(inv.args);
+            const summaryStr = inv.summary ? ` → ${inv.summary}` : '';
+            const errStr = inv.status === 'error' && inv.error ? ` — ${inv.error}` : '';
+            const durStr = inv.durationMs != null ? ` (${inv.durationMs}ms)` : '';
+            li.innerHTML =
+                '<code class="chat-tools-name">' + escapeHtml(inv.name) + '</code>' +
+                (argsStr ? '<span class="chat-tools-args">(' + escapeHtml(argsStr) + ')</span>' : '') +
+                (summaryStr ? '<span class="chat-tools-result">' + escapeHtml(summaryStr) + '</span>' : '') +
+                (errStr ? '<span class="chat-tools-error">' + escapeHtml(errStr) + '</span>' : '') +
+                '<span class="chat-tools-duration">' + escapeHtml(durStr) + '</span>';
+            list.appendChild(li);
+        }
+        panel.appendChild(list);
+        messagesEl.appendChild(panel);
         scrollToBottom();
     }
 

--- a/js/chat.js
+++ b/js/chat.js
@@ -276,6 +276,9 @@
 
             if (!res.ok) {
                 const data = await res.json().catch(() => ({}));
+                if (data.toolsUsed && data.toolsUsed.length > 0) {
+                    renderToolsUsedPanel(data.toolsUsed);
+                }
                 if (data.error === 'no_api_key') {
                     appendMessage('assistant', t('chat.errorNoKey'));
                 } else if (data.error === 'invalid_api_key') {

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -504,6 +504,8 @@ const translations = {
     'chat.editCancelled': 'Edit cancelled.',
     'chat.allEditsCancelled': 'All edits cancelled.',
     'chat.editExpired': 'This edit has expired. Please request it again.',
+    'chat.toolsUsedOne': '1 tool used',
+    'chat.toolsUsedMany': '{count} tools used',
     'chat.currentValue': 'Current',
     'chat.newValue': 'New',
   },
@@ -1011,6 +1013,8 @@ const translations = {
     'chat.editCancelled': 'Edição cancelada.',
     'chat.allEditsCancelled': 'Todas as edições canceladas.',
     'chat.editExpired': 'Esta edição expirou. Solicite novamente.',
+    'chat.toolsUsedOne': '1 ferramenta utilizada',
+    'chat.toolsUsedMany': '{count} ferramentas utilizadas',
     'chat.currentValue': 'Atual',
     'chat.newValue': 'Novo',
   }

--- a/server.js
+++ b/server.js
@@ -3405,18 +3405,58 @@ async function toolUndoLastEdit(userId, args) {
 }
 
 // Picks a small, safe subset of tool arguments to surface in the UI.
-// We never expose anything sensitive; tool args are entry IDs, dates, queries,
-// limits, etc. We just trim long strings so the chip stays compact.
+// Tool args are model-controlled and untrusted, so we hard-cap the number of
+// keys, the size of each string/array, and refuse anything that isn't a plain
+// data type. Sensitive internal flags (e.g. confirmed) are stripped.
+const MAX_SANITIZED_TOOL_ARG_KEYS = 20;
+const MAX_SANITIZED_TOOL_ARG_ARRAY_ITEMS = 10;
+const MAX_SANITIZED_TOOL_ARG_STRING_LENGTH = 80;
+
+function isPlainObject(value) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+    const proto = Object.getPrototypeOf(value);
+    return proto === Object.prototype || proto === null;
+}
+
+function sanitizeToolArgString(value) {
+    return value.length > MAX_SANITIZED_TOOL_ARG_STRING_LENGTH
+        ? value.slice(0, MAX_SANITIZED_TOOL_ARG_STRING_LENGTH - 1) + '…'
+        : value;
+}
+
+function sanitizeToolArgArrayValue(value) {
+    if (value == null) return null;
+    if (typeof value === 'string') return sanitizeToolArgString(value);
+    if (typeof value === 'number' || typeof value === 'boolean') return value;
+    if (Array.isArray(value)) return '[array]';
+    if (isPlainObject(value)) return '[object]';
+    return null;
+}
+
 function sanitizeToolArgs(args) {
-    if (!args || typeof args !== 'object') return {};
+    if (!isPlainObject(args)) return {};
     const out = {};
+    let captured = 0;
     for (const [k, v] of Object.entries(args)) {
+        if (captured >= MAX_SANITIZED_TOOL_ARG_KEYS) break;
         if (k === 'confirmed') continue;
         if (v == null) continue;
-        if (typeof v === 'string') out[k] = v.length > 80 ? v.slice(0, 77) + '…' : v;
-        else if (Array.isArray(v)) out[k] = v.slice(0, 10);
-        else if (typeof v === 'number' || typeof v === 'boolean') out[k] = v;
-        else if (typeof v === 'object') out[k] = '[object]';
+        if (typeof v === 'string') {
+            out[k] = sanitizeToolArgString(v);
+            captured++;
+        } else if (typeof v === 'number' || typeof v === 'boolean') {
+            out[k] = v;
+            captured++;
+        } else if (Array.isArray(v)) {
+            out[k] = v
+                .slice(0, MAX_SANITIZED_TOOL_ARG_ARRAY_ITEMS)
+                .map(sanitizeToolArgArrayValue)
+                .filter(item => item != null);
+            captured++;
+        } else if (isPlainObject(v)) {
+            out[k] = '[object]';
+            captured++;
+        }
     }
     return out;
 }
@@ -3582,12 +3622,16 @@ app.post('/api/ai/chat', requireAuth, chatRateLimiter, asyncHandler(async (req, 
                     result = await executeTool(toolName, req.user.id, toolArgs);
                 }
             } catch (err) {
-                const errorMessage = (err && err.message) ? String(err.message) : 'unknown error';
+                const fullMessage = (err && err.message) ? String(err.message) : 'unknown error';
+                // Log the real error server-side; surface only a generic, safe
+                // message to the UI/model to avoid leaking internal details
+                // (DB error text, stack traces, driver-specific identifiers).
+                console.error(`Tool ${toolName} threw:`, fullMessage, err && err.stack ? err.stack : '');
+                const safeMessage = 'Tool execution failed.';
                 record.status = 'error';
-                record.error = errorMessage.slice(0, 200);
+                record.error = safeMessage;
                 record.durationMs = Date.now() - startedAt;
-                console.error(`Tool ${toolName} threw:`, errorMessage);
-                return { error: errorMessage };
+                return { error: safeMessage };
             }
             record.durationMs = Date.now() - startedAt;
             if (result && typeof result === 'object') {

--- a/server.js
+++ b/server.js
@@ -3404,6 +3404,57 @@ async function toolUndoLastEdit(userId, args) {
     };
 }
 
+// Picks a small, safe subset of tool arguments to surface in the UI.
+// We never expose anything sensitive; tool args are entry IDs, dates, queries,
+// limits, etc. We just trim long strings so the chip stays compact.
+function sanitizeToolArgs(args) {
+    if (!args || typeof args !== 'object') return {};
+    const out = {};
+    for (const [k, v] of Object.entries(args)) {
+        if (k === 'confirmed') continue;
+        if (v == null) continue;
+        if (typeof v === 'string') out[k] = v.length > 80 ? v.slice(0, 77) + '…' : v;
+        else if (Array.isArray(v)) out[k] = v.slice(0, 10);
+        else if (typeof v === 'number' || typeof v === 'boolean') out[k] = v;
+        else if (typeof v === 'object') out[k] = '[object]';
+    }
+    return out;
+}
+
+// Builds a one-line human-readable summary of what a tool returned, for the UI.
+// Returns null when nothing useful can be summarized.
+function summarizeToolResult(toolName, result) {
+    if (!result || typeof result !== 'object' || result.error) return null;
+    switch (toolName) {
+        case 'searchEntries': {
+            const total = result.totalMatches != null ? result.totalMatches : (result.results ? result.results.length : null);
+            const showing = result.showing != null ? result.showing : (result.results ? result.results.length : null);
+            if (total == null) return null;
+            return showing != null && showing !== total
+                ? `${total} match(es), showing ${showing}`
+                : `${total} match(es)`;
+        }
+        case 'getTopExpenses': {
+            const n = Array.isArray(result.topExpenses) ? result.topExpenses.length : null;
+            return n != null ? `${n} entries` : null;
+        }
+        case 'getFinancialSummary':
+            return result.entryCount != null ? `${result.entryCount} entries analyzed` : null;
+        case 'getCategoryBreakdown':
+            return Array.isArray(result.categories) ? `${result.categories.length} categories` : null;
+        case 'getMonthlyTrends':
+            return Array.isArray(result.months) ? `${result.months.length} months` : null;
+        case 'comparePeriods':
+            return 'compared';
+        case 'editEntry':
+            return result.pending ? 'awaiting confirmation' : 'updated';
+        case 'undoLastEdit':
+            return 'restored';
+        default:
+            return null;
+    }
+}
+
 async function executeTool(name, userId, args) {
     switch (name) {
         case 'getFinancialSummary': return toolGetFinancialSummary(userId, args);
@@ -3511,7 +3562,41 @@ app.post('/api/ai/chat', requireAuth, chatRateLimiter, asyncHandler(async (req, 
     try {
         let finalText = null;
         const pendingEditsList = [];
+        const toolsUsed = []; // { name, args, status: 'success'|'error'|'pending', durationMs, summary?, error? }
         const maxIterations = 5;
+
+        // Wraps tool dispatch with tracking so the UI can show what the agent did.
+        // Returns whatever the underlying tool returns.
+        async function runToolWithTracking(toolName, toolArgs) {
+            const startedAt = Date.now();
+            const record = { name: toolName, args: sanitizeToolArgs(toolArgs), status: 'success', durationMs: 0 };
+            toolsUsed.push(record);
+            let result;
+            try {
+                if (toolName === 'editEntry') {
+                    result = await handleEditEntryCall(toolArgs, pendingEditsList);
+                } else {
+                    result = await executeTool(toolName, req.user.id, toolArgs);
+                }
+            } catch (err) {
+                record.status = 'error';
+                record.error = err.message || 'unknown error';
+                record.durationMs = Date.now() - startedAt;
+                throw err;
+            }
+            record.durationMs = Date.now() - startedAt;
+            if (result && typeof result === 'object') {
+                if (result.error) {
+                    record.status = 'error';
+                    record.error = String(result.error).slice(0, 200);
+                } else if (result.pending) {
+                    record.status = 'pending';
+                }
+                const summary = summarizeToolResult(toolName, result);
+                if (summary) record.summary = summary;
+            }
+            return result;
+        }
 
         if (provider === 'openai') {
             // ── OpenAI branch ──────────────────────────────────────────
@@ -3554,12 +3639,7 @@ app.post('/api/ai/chat', requireAuth, chatRateLimiter, asyncHandler(async (req, 
                     try { toolArgs = JSON.parse(toolCall.function.arguments || '{}'); } catch (parseErr) {
                         console.error(`Failed to parse OpenAI tool args for ${toolName}:`, parseErr.message);
                     }
-                    let result;
-                    if (toolName === 'editEntry') {
-                        result = await handleEditEntryCall(toolArgs, pendingEditsList);
-                    } else {
-                        result = await executeTool(toolName, req.user.id, toolArgs);
-                    }
+                    const result = await runToolWithTracking(toolName, toolArgs);
                     toolResultMessages.push({
                         role: 'tool',
                         tool_call_id: toolCall.id,
@@ -3613,12 +3693,7 @@ app.post('/api/ai/chat', requireAuth, chatRateLimiter, asyncHandler(async (req, 
                     try { toolArgs = JSON.parse(toolCall.function.arguments || '{}'); } catch (parseErr) {
                         console.error(`Failed to parse Copilot tool args for ${toolName}:`, parseErr.message);
                     }
-                    let result;
-                    if (toolName === 'editEntry') {
-                        result = await handleEditEntryCall(toolArgs, pendingEditsList);
-                    } else {
-                        result = await executeTool(toolName, req.user.id, toolArgs);
-                    }
+                    const result = await runToolWithTracking(toolName, toolArgs);
                     toolResultMessages.push({
                         role: 'tool',
                         tool_call_id: toolCall.id,
@@ -3679,12 +3754,7 @@ app.post('/api/ai/chat', requireAuth, chatRateLimiter, asyncHandler(async (req, 
                 for (const toolUse of toolUseBlocks) {
                     const toolName = toolUse.name;
                     const toolArgs = toolUse.input || {};
-                    let result;
-                    if (toolName === 'editEntry') {
-                        result = await handleEditEntryCall(toolArgs, pendingEditsList);
-                    } else {
-                        result = await executeTool(toolName, req.user.id, toolArgs);
-                    }
+                    const result = await runToolWithTracking(toolName, toolArgs);
                     toolResults.push({
                         type: 'tool_result',
                         tool_use_id: toolUse.id,
@@ -3762,12 +3832,7 @@ app.post('/api/ai/chat', requireAuth, chatRateLimiter, asyncHandler(async (req, 
                 for (const fc of functionCalls) {
                     const toolName = fc.functionCall.name;
                     const toolArgs = fc.functionCall.args || {};
-                    let result;
-                    if (toolName === 'editEntry') {
-                        result = await handleEditEntryCall(toolArgs, pendingEditsList);
-                    } else {
-                        result = await executeTool(toolName, req.user.id, toolArgs);
-                    }
+                    const result = await runToolWithTracking(toolName, toolArgs);
                     toolResultParts.push({
                         functionResponse: { name: toolName, response: result }
                     });
@@ -3783,6 +3848,9 @@ app.post('/api/ai/chat', requireAuth, chatRateLimiter, asyncHandler(async (req, 
         const responsePayload = { reply: finalText };
         if (pendingEditsList.length > 0) {
             responsePayload.pendingEdits = pendingEditsList;
+        }
+        if (toolsUsed.length > 0) {
+            responsePayload.toolsUsed = toolsUsed;
         }
         res.json(responsePayload);
     } catch (error) {

--- a/server.js
+++ b/server.js
@@ -3559,14 +3559,17 @@ app.post('/api/ai/chat', requireAuth, chatRateLimiter, asyncHandler(async (req, 
         return { pending: true, message: 'Edit sent to user for UI confirmation. Tell them what you proposed and that they can use the buttons to confirm or cancel.' };
     }
 
+    const toolsUsed = []; // hoisted so error responses can include it { name, args, status: 'success'|'error'|'pending', durationMs, summary?, error? }
+
     try {
         let finalText = null;
         const pendingEditsList = [];
-        const toolsUsed = []; // { name, args, status: 'success'|'error'|'pending', durationMs, summary?, error? }
         const maxIterations = 5;
 
         // Wraps tool dispatch with tracking so the UI can show what the agent did.
-        // Returns whatever the underlying tool returns.
+        // Returns whatever the underlying tool returns. Tool exceptions are caught
+        // and converted to a structured `{ error }` result so the model can keep
+        // iterating, and the failure is recorded in toolsUsed for the UI.
         async function runToolWithTracking(toolName, toolArgs) {
             const startedAt = Date.now();
             const record = { name: toolName, args: sanitizeToolArgs(toolArgs), status: 'success', durationMs: 0 };
@@ -3579,10 +3582,12 @@ app.post('/api/ai/chat', requireAuth, chatRateLimiter, asyncHandler(async (req, 
                     result = await executeTool(toolName, req.user.id, toolArgs);
                 }
             } catch (err) {
+                const errorMessage = (err && err.message) ? String(err.message) : 'unknown error';
                 record.status = 'error';
-                record.error = err.message || 'unknown error';
+                record.error = errorMessage.slice(0, 200);
                 record.durationMs = Date.now() - startedAt;
-                throw err;
+                console.error(`Tool ${toolName} threw:`, errorMessage);
+                return { error: errorMessage };
             }
             record.durationMs = Date.now() - startedAt;
             if (result && typeof result === 'object') {
@@ -3855,21 +3860,28 @@ app.post('/api/ai/chat', requireAuth, chatRateLimiter, asyncHandler(async (req, 
         res.json(responsePayload);
     } catch (error) {
         console.error('AI Chat error:', error.message, error.status ? `(status ${error.status})` : '');
+        // Helper: include any tools that did run before the failure, so the UI
+        // can still show them in the "tools used" panel even on errors.
+        const errorPayload = (code, status) => {
+            const payload = { error: code };
+            if (toolsUsed.length > 0) payload.toolsUsed = toolsUsed;
+            return res.status(status).json(payload);
+        };
         // Surface the Copilot-specific "no token decryptable + no env fallback"
         // case as the same no_api_key UX the providers use up front.
         if (error.code === 'no_copilot_token') {
-            return res.status(400).json({ error: 'no_api_key' });
+            return errorPayload('no_api_key', 400);
         }
         // Treat 401 and 403 as auth failures: some providers (incl. the Copilot
         // token-exchange endpoint) return 403 for unauthorized tokens/keys.
         if (error.message?.includes('API key') || error.message?.includes('authentication')
             || error.status === 401 || error.status === 403) {
-            return res.status(400).json({ error: 'invalid_api_key' });
+            return errorPayload('invalid_api_key', 400);
         }
         if (error.message?.includes('quota') || error.message?.includes('credit balance') || error.status === 429) {
-            return res.status(429).json({ error: 'quota_exceeded' });
+            return errorPayload('quota_exceeded', 429);
         }
-        res.status(500).json({ error: 'generic' });
+        errorPayload('generic', 500);
     }
 }));
 

--- a/server.js
+++ b/server.js
@@ -3441,7 +3441,7 @@ function summarizeToolResult(toolName, result) {
         case 'getFinancialSummary':
             return result.entryCount != null ? `${result.entryCount} entries analyzed` : null;
         case 'getCategoryBreakdown':
-            return Array.isArray(result.categories) ? `${result.categories.length} categories` : null;
+            return Array.isArray(result.breakdown) ? `${result.breakdown.length} categories` : null;
         case 'getMonthlyTrends':
             return Array.isArray(result.months) ? `${result.months.length} months` : null;
         case 'comparePeriods':


### PR DESCRIPTION
Closes #57.

## What

The chat agent silently calls server-side tools to look up data, edit entries, search the database, etc. Until now the user had **no visibility** into which tools ran or what they returned. This PR adds a collapsible **"tools used"** panel under each assistant reply.

## How it looks

Above each assistant reply: a small purple-tinted bar like  
`🔧 3 tools used  ▸`

Click to expand into a list, where each invocation shows:
- **Tool name** (monospace) — e.g. `searchEntries`
- **Key args** (inline) — e.g. `(query: groceries · limit: 10)`
- **Result summary** — e.g. `→ 12 match(es), showing 5`
- **Status color** — green border for success, red for error, amber for awaiting confirmation
- **Duration** — e.g. `23ms`

## Server (`server.js`)

- New `sanitizeToolArgs()` strips internal flags (e.g. `confirmed`), truncates long strings, shrinks arrays.
- New `summarizeToolResult()` generates a short human-readable line per tool (e.g. `12 match(es)` for searchEntries, `6 categories` for getCategoryBreakdown, `12 months` for getMonthlyTrends).
- New `runToolWithTracking()` closure inside the chat handler. It now owns the `editEntry`-vs-other dispatch that was previously duplicated in all four provider branches, records start/end timestamps, captures status, and appends a record to a per-request `toolsUsed` array.
- Each provider branch (OpenAI / Copilot / Anthropic / Gemini) lost its inline `if (toolName === 'editEntry') ... else ...` block — replaced by a single call to `runToolWithTracking`. Net: less code, single dispatch site.
- Response payload gains an optional `toolsUsed` array when at least one tool was invoked.

## Frontend

- `renderToolsUsedPanel()` renders a `<details>` element above each assistant reply.
- New CSS for the panel, list, name, args, result, error, and duration styles.
- 2 new i18n keys (EN + PT): `chat.toolsUsedOne`, `chat.toolsUsedMany`.

## Notes / future work

- This is **post-hoc** visibility (shown when the response arrives). Real-time "tool is running…" streaming would require switching all four providers to streaming APIs and an SSE endpoint — a much larger change. This MVP delivers the requested visibility today and a streaming version can be a follow-up if desired.
- Args are lightly sanitized but never sensitive — tool args are entry IDs, search queries, dates, etc.

No DB migration. No env-var changes. Backward-compatible: clients that ignore `toolsUsed` work unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>