### PR TITLE
Show AI web_search calls in the chat tools-used panel (closes #65)

### DIFF
--- a/js/chat.js
+++ b/js/chat.js
@@ -484,7 +484,18 @@
             const li = document.createElement('li');
             li.className = 'chat-tools-item chat-tools-item--' + (inv.status || 'success');
             const argsStr = formatToolArgs(inv.args);
-            const summaryStr = inv.summary ? ` → ${inv.summary}` : '';
+            // web_search records carry a structured searchCount so we can
+            // localize the "N searches" summary instead of relying on a
+            // server-side English string.
+            let summaryText;
+            if (inv.name === 'web_search' && typeof inv.searchCount === 'number') {
+                summaryText = inv.searchCount === 1
+                    ? t('chat.webSearchCountOne')
+                    : t('chat.webSearchCountMany', { count: inv.searchCount });
+            } else {
+                summaryText = inv.summary;
+            }
+            const summaryStr = summaryText ? ` → ${summaryText}` : '';
             const errStr = inv.status === 'error' && inv.error ? ` — ${inv.error}` : '';
             const durStr = inv.durationMs != null ? ` (${inv.durationMs}ms)` : '';
             li.innerHTML =

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -514,6 +514,8 @@ const translations = {
     'chat.editExpired': 'This edit has expired. Please request it again.',
     'chat.toolsUsedOne': '1 tool used',
     'chat.toolsUsedMany': '{count} tools used',
+    'chat.webSearchCountOne': '1 search',
+    'chat.webSearchCountMany': '{count} searches',
     'chat.currentValue': 'Current',
     'chat.newValue': 'New',
   },
@@ -1031,6 +1033,8 @@ const translations = {
     'chat.editExpired': 'Esta edição expirou. Solicite novamente.',
     'chat.toolsUsedOne': '1 ferramenta utilizada',
     'chat.toolsUsedMany': '{count} ferramentas utilizadas',
+    'chat.webSearchCountOne': '1 busca',
+    'chat.webSearchCountMany': '{count} buscas',
     'chat.currentValue': 'Atual',
     'chat.newValue': 'Novo',
   }

--- a/server.js
+++ b/server.js
@@ -4201,7 +4201,7 @@ app.post('/api/ai/chat', requireAuth, chatRateLimiter, asyncHandler(async (req, 
                     }
                     toolsUsed.push({
                         name: 'web_search',
-                        args: queries.length > 0 ? { queries } : {},
+                        args: queries.length > 0 ? sanitizeToolArgs({ queries }) : {},
                         status: 'success',
                         searchCount: searchesUsed
                     });

--- a/server.js
+++ b/server.js
@@ -4185,6 +4185,27 @@ app.post('/api/ai/chat', requireAuth, chatRateLimiter, asyncHandler(async (req, 
                     && Number(response.usage.server_tool_use.web_search_requests);
                 if (Number.isFinite(searchesUsed) && searchesUsed > 0) {
                     bumpWebSearchUsage(req.user.id, searchesUsed);
+
+                    // Surface the searches in the chat "tools used" panel so users
+                    // see them alongside client tools. server_tool_use blocks are
+                    // executed by Anthropic — runToolWithTracking is bypassed —
+                    // so we synthesize the record here. Query strings are pulled
+                    // from the matching server_tool_use blocks in this response.
+                    const queries = [];
+                    for (const block of response.content) {
+                        if (block.type === 'server_tool_use' && block.name === 'web_search'
+                            && block.input && typeof block.input.query === 'string') {
+                            const q = block.input.query.trim();
+                            if (q) queries.push(q.length > 80 ? q.slice(0, 77) + '…' : q);
+                        }
+                    }
+                    toolsUsed.push({
+                        name: 'web_search',
+                        args: queries.length > 0 ? { queries } : {},
+                        status: 'success',
+                        searchCount: searchesUsed
+                    });
+
                     if (getWebSearchUsage(req.user.id).count >= WEB_SEARCH_DAILY_CAP) {
                         webSearchActive = false;
                         currentTools = anthropicToolDeclarations;


### PR DESCRIPTION
Closes #65.

When the Anthropic chat runs the native `web_search` server tool, the request count was being tracked for the daily cap but wasn't surfaced in the existing 'tools used' panel that lists client tool invocations (`getEntries`, `editEntry`, etc.). Users could only tell that a search ran from the inline `[N]` markers and the Sources block — easy to miss if the model didn't cite inline.

## What changed

**`server.js`** — right after the daily-cap accounting in the Anthropic loop, synthesize one `toolsUsed` record per response that recorded searches:

```js
{
  name: 'web_search',
  args: { queries: [...] },   // pulled from response.content[server_tool_use blocks].input.query
  status: 'success',
  searchCount: N              // from response.usage.server_tool_use.web_search_requests
}
```

Each query is trimmed and capped at 80 chars so the chip stays compact. `server_tool_use` blocks are still excluded from `runToolWithTracking` (Anthropic executes them in their own infra) — the record is built locally instead.

**`js/chat.js`** — `renderToolsUsedPanel` special-cases `web_search` records: builds the summary from `chat.webSearchCountOne` / `chat.webSearchCountMany` so the count text follows the user's locale instead of a server-side English string. The existing `formatToolArgs` already renders the `{ queries: [...] }` array nicely (`queries: foo, bar`), so no change needed there.

**`js/i18n.js`** — two new keys (EN + PT):
- `chat.webSearchCountOne` — '1 search' / '1 busca'
- `chat.webSearchCountMany` — '{count} searches' / '{count} buscas'

## Behavior

The 'tools used' chip now reads roughly:
```
🔧 1 tool used
  • web_search(queries: pagseguro xyz, lojas americanas) → 2 searches
```

## Edge cases considered

- **pause_turn iteration** — each loop iteration's response is independent; `searchesUsed` is per-response, so no double-count if the model pauses and resumes.
- **Capability-fallback retry** — happens *inside* the try/catch before the tracking block, so the retry's response gets accounted for normally.
- **`searchesUsed > 0` but no `server_tool_use` blocks** (defensive) — `args` becomes `{}` and `formatToolArgs` returns `''`, so no parens are rendered. `searchCount` still surfaces.

## Out of scope

- Per-search timing (Anthropic doesn't expose it).
- Search-result snippets (already in the Sources block).
- Other providers — they don't run native search yet.

## Testing

- `node --check` clean for `server.js`, `js/chat.js`, `js/i18n.js`.
- No DB / config changes.