### PR TITLE
feat(#69): paginate entries table at 30 per page

### DIFF
--- a/index.html
+++ b/index.html
@@ -763,6 +763,49 @@
             border: 1px solid var(--color-border);
             position: relative;
         }
+        .entries-pagination {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+            margin-top: 0.85rem;
+            padding: 0.5rem 0.25rem;
+            color: var(--color-text-secondary);
+            font-size: 0.85rem;
+            flex-wrap: wrap;
+        }
+        .entries-pagination[hidden] { display: none; }
+        .entries-pagination-info {
+            color: var(--color-text-secondary);
+        }
+        .entries-pagination-controls {
+            display: inline-flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+        .entries-pagination-btn {
+            background: var(--color-surface, #1e293b);
+            color: var(--color-text, #e2e8f0);
+            border: 1px solid var(--color-border, #334155);
+            border-radius: var(--radius-md, 0.4rem);
+            padding: 0.35rem 0.75rem;
+            font-size: 0.85rem;
+            cursor: pointer;
+            transition: background 0.15s ease, border-color 0.15s ease, opacity 0.15s ease;
+        }
+        .entries-pagination-btn:hover:not(:disabled) {
+            background: var(--color-surface-hover, #334155);
+            border-color: var(--color-accent, #f59e0b);
+        }
+        .entries-pagination-btn:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
+        .entries-pagination-indicator {
+            min-width: 6rem;
+            text-align: center;
+            color: var(--color-text, #e2e8f0);
+        }
         .table-loading-overlay {
             position: absolute;
             inset: 0;
@@ -2666,6 +2709,7 @@
                         </tbody>
                     </table>
                 </div>
+                <div id="entriesPagination" class="entries-pagination" hidden role="navigation" data-i18n-aria-label="pagination.navLabel" aria-label="Entries pagination"></div>
             </section>
         </main>
     </div>

--- a/js/app.js
+++ b/js/app.js
@@ -1115,16 +1115,35 @@ function updateSortIndicators() {
 }
 
 // Display entries in the table
+// Caches the last sort result keyed by source-array identity + sort settings,
+// so paginating a large list doesn't re-sort O(n log n) on every Prev/Next.
+let _sortedEntriesCache = { source: null, column: null, direction: null, result: null };
 function displayEntries(entriesToShow) {
     const tbody = document.getElementById('entriesBody');
     tbody.innerHTML = '';
 
-    // Apply current sorting if set, otherwise default to month descending
+    // Apply current sorting if set, otherwise default to month descending.
+    // filterEntries() always reassigns currentFilteredEntries to a new array,
+    // so reference equality is enough to detect "filter changed".
     let sortedEntries;
-    if (currentSortColumn) {
-        sortedEntries = sortEntries(entriesToShow, currentSortColumn, currentSortDirection);
+    const cache = _sortedEntriesCache;
+    if (cache.source === entriesToShow
+        && cache.column === currentSortColumn
+        && cache.direction === currentSortDirection
+        && cache.result) {
+        sortedEntries = cache.result;
     } else {
-        sortedEntries = [...entriesToShow].sort((a, b) => b.month.localeCompare(a.month));
+        if (currentSortColumn) {
+            sortedEntries = sortEntries(entriesToShow, currentSortColumn, currentSortDirection);
+        } else {
+            sortedEntries = [...entriesToShow].sort((a, b) => b.month.localeCompare(a.month));
+        }
+        _sortedEntriesCache = {
+            source: entriesToShow,
+            column: currentSortColumn,
+            direction: currentSortDirection,
+            result: sortedEntries,
+        };
     }
 
     // Pagination: clamp currentPage so deletes/edits that shrink the list

--- a/js/app.js
+++ b/js/app.js
@@ -63,6 +63,10 @@ let currentUser = null;
 let currentSortColumn = null;
 let currentSortDirection = 'asc';
 
+// Pagination state for the entries table (issue #69)
+const ENTRIES_PAGE_SIZE = 30;
+let currentPage = 1;
+
 // Couple feature state
 let currentViewMode = 'individual';
 let hasPartner = false;
@@ -1018,7 +1022,12 @@ function updateFilterResultsCount(filtered) {
 }
 
 // Filter entries based on selected criteria
-function filterEntries() {
+function filterEntries(opts) {
+    // Filter changes reset to page 1 by default; entry mutations (delete)
+    // pass { resetPage: false } so we just clamp inside displayEntries() and
+    // keep the user near the row they just touched.
+    const resetPage = !opts || opts.resetPage !== false;
+    if (resetPage) currentPage = 1;
     const monthFilterStart = filterState.start;
     const monthFilterEnd = filterState.end;
     const typeFilter = filterState.type;
@@ -1118,7 +1127,16 @@ function displayEntries(entriesToShow) {
         sortedEntries = [...entriesToShow].sort((a, b) => b.month.localeCompare(a.month));
     }
 
-    sortedEntries.forEach(entry => {
+    // Pagination: clamp currentPage so deletes/edits that shrink the list
+    // never leave us on a page that no longer exists.
+    const totalEntries = sortedEntries.length;
+    const totalPages = Math.max(1, Math.ceil(totalEntries / ENTRIES_PAGE_SIZE));
+    if (currentPage > totalPages) currentPage = totalPages;
+    if (currentPage < 1) currentPage = 1;
+    const startIdx = (currentPage - 1) * ENTRIES_PAGE_SIZE;
+    const pageEntries = sortedEntries.slice(startIdx, startIdx + ENTRIES_PAGE_SIZE);
+
+    pageEntries.forEach(entry => {
         const row = document.createElement('tr');
         const escapedDescription = escapeHtml(entry.description);
         const tags = (entry.tags || []).map(tag =>
@@ -1159,6 +1177,37 @@ function displayEntries(entriesToShow) {
 
     // Update sort indicators
     updateSortIndicators();
+    // Render pagination control (hidden when ≤ 1 page)
+    renderEntriesPagination(totalEntries, totalPages);
+}
+
+// Render pagination controls below the entries table.
+// Hidden entirely when there's nothing to paginate.
+function renderEntriesPagination(totalEntries, totalPages) {
+    const container = document.getElementById('entriesPagination');
+    if (!container) return;
+    if (totalEntries <= ENTRIES_PAGE_SIZE) {
+        container.hidden = true;
+        container.innerHTML = '';
+        return;
+    }
+    container.hidden = false;
+    const from = (currentPage - 1) * ENTRIES_PAGE_SIZE + 1;
+    const to = Math.min(currentPage * ENTRIES_PAGE_SIZE, totalEntries);
+    const showing = t('pagination.showing', { from, to, total: totalEntries });
+    const pageOf = t('pagination.pageOf', { current: currentPage, total: totalPages });
+    const prevLabel = t('pagination.previous');
+    const nextLabel = t('pagination.next');
+    const prevDisabled = currentPage <= 1 ? 'disabled' : '';
+    const nextDisabled = currentPage >= totalPages ? 'disabled' : '';
+    container.innerHTML = `
+        <span class="entries-pagination-info" aria-live="polite">${escapeHtml(showing)}</span>
+        <div class="entries-pagination-controls">
+            <button type="button" class="entries-pagination-btn" data-page-action="prev" ${prevDisabled} aria-label="${escapeHtml(prevLabel)}">${escapeHtml(prevLabel)}</button>
+            <span class="entries-pagination-indicator">${escapeHtml(pageOf)}</span>
+            <button type="button" class="entries-pagination-btn" data-page-action="next" ${nextDisabled} aria-label="${escapeHtml(nextLabel)}">${escapeHtml(nextLabel)}</button>
+        </div>
+    `;
 }
 
 // Update summary statistics
@@ -2015,8 +2064,10 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (response.ok) {
                         // Remove entry from the local array *without* full page reload
                         entries = entries.filter(entry => entry.id !== id);
-                        // Re-apply current filters to update the display
-                        filterEntries();
+                        // Re-apply current filters to update the display.
+                        // Preserve the current page — displayEntries() clamps
+                        // if the deletion emptied the last page.
+                        filterEntries({ resetPage: false });
                     } else {
                         console.error('Error deleting entry on server:', response.statusText);
                         alert(t('entry.alertDeleteFailed'));
@@ -2114,7 +2165,8 @@ document.addEventListener('DOMContentLoaded', () => {
         renderActiveFiltersBar();
         // Reset currentFilteredEntries to all entries
         currentFilteredEntries = entries;
-        // Reset filters should show ALL entries again
+        // Reset filters should show ALL entries again, starting from page 1
+        currentPage = 1;
         displayEntries(entries);
         updateSummary(entries);
         updateCharts(entries, true);
@@ -2136,9 +2188,34 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             // Re-display entries with new sorting using currently filtered entries
+            // Reset to page 1 — sorting reorders the result set so the user
+            // expects to start from the top.
+            currentPage = 1;
             displayEntries(currentFilteredEntries);
         });
     });
+
+    // Pagination button handler (event-delegated so re-renders don't leak
+    // listeners; container is rebuilt on every displayEntries call).
+    const paginationEl = document.getElementById('entriesPagination');
+    if (paginationEl) {
+        paginationEl.addEventListener('click', (e) => {
+            const btn = e.target.closest('[data-page-action]');
+            if (!btn || btn.disabled) return;
+            const action = btn.dataset.pageAction;
+            if (action === 'prev' && currentPage > 1) currentPage--;
+            else if (action === 'next') currentPage++;
+            else return;
+            displayEntries(currentFilteredEntries);
+            // Scroll the table into view so users see the new rows. Honor
+            // prefers-reduced-motion to avoid jumpy animation for those users.
+            const table = document.getElementById('entriesTable');
+            if (table) {
+                const reduce = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+                table.scrollIntoView({ behavior: reduce ? 'auto' : 'smooth', block: 'start' });
+            }
+        });
+    }
 
     // Add New Entry button opens modal
     document.getElementById('addEntryBtn').addEventListener('click', openModal);
@@ -3611,6 +3688,11 @@ document.addEventListener('DOMContentLoaded', () => {
         currentFilteredEntries = [];
         const tbody = document.getElementById('entriesBody');
         if (tbody) tbody.innerHTML = '';
+        // Hide stale pagination controls during the reload so prev/next can't
+        // be clicked against a now-empty list. renderEntriesPagination()
+        // restores them once filterEntries() runs with the new data.
+        const paginationEl = document.getElementById('entriesPagination');
+        if (paginationEl) { paginationEl.hidden = true; paginationEl.innerHTML = ''; }
         updateSummary([]);
         setViewLoading(true);
 

--- a/js/app.js
+++ b/js/app.js
@@ -2130,8 +2130,10 @@ document.addEventListener('DOMContentLoaded', () => {
             });
 
             if (response.ok) {
-                // Reload entries from server to ensure view mode filtering is applied correctly
-                await loadEntries();
+                // Reload entries from server so view-mode filtering stays correct,
+                // but preserve the user's current page (displayEntries() clamps
+                // if the edit somehow shrinks the visible set).
+                await loadEntries({ resetPage: false });
                 document.getElementById('editEntryModal').style.display = 'none';
             } else {
                 alert(t('entry.alertUpdateFailed'));
@@ -2207,6 +2209,16 @@ document.addEventListener('DOMContentLoaded', () => {
             else if (action === 'next') currentPage++;
             else return;
             displayEntries(currentFilteredEntries);
+            // Re-render replaces the buttons, so restore focus to the matching
+            // new button to keep keyboard users in place. If that button is
+            // now disabled (we hit a boundary), fall back to the opposite one.
+            const fresh = paginationEl.querySelector(`[data-page-action="${action}"]`);
+            if (fresh && !fresh.disabled) {
+                fresh.focus();
+            } else {
+                const other = paginationEl.querySelector(`[data-page-action="${action === 'prev' ? 'next' : 'prev'}"]`);
+                if (other) other.focus();
+            }
             // Scroll the table into view so users see the new rows. Honor
             // prefers-reduced-motion to avoid jumpy animation for those users.
             const table = document.getElementById('entriesTable');
@@ -3704,8 +3716,10 @@ document.addEventListener('DOMContentLoaded', () => {
     // before the user clicks Combined) can never overwrite the latest view.
     let loadEntriesSeq = 0;
 
-    // Load entries from server with viewMode
-    async function loadEntries() {
+    // Load entries from server with viewMode.
+    // opts.resetPage (default true) is forwarded to filterEntries() so that
+    // edit-triggered reloads can preserve the user's current page.
+    async function loadEntries(opts) {
         const seq = ++loadEntriesSeq;
         try {
             setViewLoading(true);
@@ -3716,7 +3730,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 entries = await response.json();
                 if (seq !== loadEntriesSeq) return;
                 // Re-apply any active filters so the UI stays consistent
-                filterEntries();
+                filterEntries(opts);
             }
         } catch (error) {
             console.error('Error loading entries:', error);

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -28,6 +28,11 @@ const translations = {
     'common.created': 'Created',
     'common.role': 'Role',
     'common.partner': 'Partner',
+    'pagination.previous': 'Previous',
+    'pagination.next': 'Next',
+    'pagination.pageOf': 'Page {current} of {total}',
+    'pagination.showing': 'Showing {from}–{to} of {total}',
+    'pagination.navLabel': 'Entries pagination',
 
     // ── Types ──
     'type.income': 'Income',
@@ -561,6 +566,11 @@ const translations = {
     'common.created': 'Criado',
     'common.role': 'Fun\u00e7\u00e3o',
     'common.partner': 'Parceiro(a)',
+    'pagination.previous': 'Anterior',
+    'pagination.next': 'Pr\u00f3xima',
+    'pagination.pageOf': 'P\u00e1gina {current} de {total}',
+    'pagination.showing': 'Mostrando {from}\u2013{to} de {total}',
+    'pagination.navLabel': 'Pagina\u00e7\u00e3o de entradas',
 
     // ── Types ──
     'type.income': 'Receita',


### PR DESCRIPTION
Closes #69.

## Summary
Adds client-side pagination to the main dashboard entries table at **30 rows per page**, preserving all existing filter, sort, and view behavior.

## Behavior
- After filtering + sorting, only the current page (30 rows) is rendered into `#entriesBody`.
- Pagination control sits below the table: `Showing X–Y of Z` + `Previous / Page x of y / Next`.
- Hidden entirely when the filtered set has ≤ 30 rows.
- Prev/Next buttons disable correctly at the boundaries.
- Filter, sort, view-mode, and clear-filters changes all **reset to page 1**.
- Delete preserves the current page; `displayEntries` clamps the page index when the last page becomes empty.
- View-mode change hides stale pagination during the reload so prev/next can't be clicked against an empty list.
- Smooth-scroll on page change respects `prefers-reduced-motion`.

## Files
- `js/app.js` — pagination state, slice in `displayEntries`, `renderEntriesPagination()`, `filterEntries({ resetPage })` opt-out for the delete handler, click-delegated prev/next handler.
- `index.html` — new `#entriesPagination` container + CSS.
- `js/i18n.js` — 5 new keys (`pagination.previous/next/pageOf/showing/navLabel`) in EN + PT.

## Acceptance criteria
- [x] At most 30 rows rendered per page.
- [x] Pagination shown only when > 30 filtered entries.
- [x] Prev/Next disable correctly.
- [x] Filter/sort/view changes reset to page 1.
- [x] Delete preserves a sensible page (clamp if the last page emptied).
- [x] EN + PT translations.
- [x] Empty / no-results states unchanged.

No DB or config changes — restart-only deploy.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>