### PR TITLE
feat(#73): cap categories per user at 100 across all creation paths

### DIFF
--- a/db/queries.js
+++ b/db/queries.js
@@ -839,9 +839,8 @@ const DEFAULT_CATEGORY_SLUGS = new Set(DEFAULT_CATEGORIES.map(c => c.slug));
 
 // Maximum number of category rows allowed per user. Enforced across
 // every code path that can create a row (POST /api/categories, AI
-// editEntry auto-create, partner import). Defaults are included in
-// the count — but resetUserCategoriesToDefaults can never push a
-// user over the cap because it only upserts the 17 canonical slugs.
+// editEntry auto-create, partner import, restore-defaults). Defaults
+// are included in the count.
 const MAX_CATEGORIES_PER_USER = 100;
 
 async function countUserCategories(userId) {
@@ -932,7 +931,6 @@ async function addUserCategoryAtomicWithCap(userId, { slug, label, color, sortOr
             [userId]
         );
         if (countRows[0].n >= MAX_CATEGORIES_PER_USER) {
-            await client.query('ROLLBACK');
             const e = new Error(`User ${userId} is at the per-user category cap (${MAX_CATEGORIES_PER_USER}).`);
             e.code = CATEGORY_CAP_ERROR_CODE;
             throw e;
@@ -989,27 +987,66 @@ async function deleteUserCategory(userId, slug) {
 // sort_order — even if a row for that slug already exists as a
 // non-default (e.g. partner import or AI auto-create predating the
 // default-slug guards). Truly custom (non-default) slugs are untouched.
+//
+// Cap-aware: the upsert only ever *creates* rows for default slugs the
+// user is missing (a deleted default), so its row-count delta equals the
+// number of missing defaults. We compute headroom under the same per-user
+// advisory lock used by the other creation paths and reject with a typed
+// CATEGORY_CAP_ERROR_CODE when restoring would exceed the cap. Defaults
+// already present (which is the steady-state for most users) are pure
+// updates and never blocked.
 async function resetUserCategoriesToDefaults(userId) {
-    const values = [];
-    const params = [userId];
-    let i = 2;
-    for (let idx = 0; idx < DEFAULT_CATEGORIES.length; idx++) {
-        const c = DEFAULT_CATEGORIES[idx];
-        values.push(`($1, $${i++}, $${i++}, $${i++}, TRUE, $${i++})`);
-        params.push(c.slug, c.slug, c.color, idx);
+    const client = await pool.connect();
+    try {
+        await client.query('BEGIN');
+        await client.query('SELECT pg_advisory_xact_lock($1)', [userId]);
+        const { rows: presentRows } = await client.query(
+            `SELECT slug FROM user_categories WHERE user_id = $1 AND slug = ANY($2::text[])`,
+            [userId, DEFAULT_CATEGORIES.map(c => c.slug)]
+        );
+        const present = new Set(presentRows.map(r => r.slug));
+        const missingCount = DEFAULT_CATEGORIES.length - present.size;
+        if (missingCount > 0) {
+            const { rows: countRows } = await client.query(
+                'SELECT COUNT(*)::int AS n FROM user_categories WHERE user_id = $1',
+                [userId]
+            );
+            const headroom = Math.max(0, MAX_CATEGORIES_PER_USER - countRows[0].n);
+            if (missingCount > headroom) {
+                const e = new Error(`User ${userId} cannot restore ${missingCount} default(s); only ${headroom} slot(s) available under the ${MAX_CATEGORIES_PER_USER}-category cap.`);
+                e.code = CATEGORY_CAP_ERROR_CODE;
+                e.missingCount = missingCount;
+                e.headroom = headroom;
+                throw e;
+            }
+        }
+        const values = [];
+        const params = [userId];
+        let i = 2;
+        for (let idx = 0; idx < DEFAULT_CATEGORIES.length; idx++) {
+            const c = DEFAULT_CATEGORIES[idx];
+            values.push(`($1, $${i++}, $${i++}, $${i++}, TRUE, $${i++})`);
+            params.push(c.slug, c.slug, c.color, idx);
+        }
+        await client.query(
+            `INSERT INTO user_categories (user_id, slug, label, color, is_default, sort_order)
+             VALUES ${values.join(', ')}
+             ON CONFLICT (user_id, slug) DO UPDATE SET
+                 label = EXCLUDED.label,
+                 color = EXCLUDED.color,
+                 is_default = TRUE,
+                 sort_order = EXCLUDED.sort_order,
+                 imported_from_user_id = NULL`,
+            params
+        );
+        await client.query('COMMIT');
+        return getUserCategories(userId);
+    } catch (e) {
+        try { await client.query('ROLLBACK'); } catch (_) { /* ignore */ }
+        throw e;
+    } finally {
+        client.release();
     }
-    await pool.query(
-        `INSERT INTO user_categories (user_id, slug, label, color, is_default, sort_order)
-         VALUES ${values.join(', ')}
-         ON CONFLICT (user_id, slug) DO UPDATE SET
-             label = EXCLUDED.label,
-             color = EXCLUDED.color,
-             is_default = TRUE,
-             sort_order = EXCLUDED.sort_order,
-             imported_from_user_id = NULL`,
-        params
-    );
-    return getUserCategories(userId);
 }
 
 // Find tags used in the partner's couple-flagged entries that the user

--- a/db/queries.js
+++ b/db/queries.js
@@ -1011,12 +1011,21 @@ async function resetUserCategoriesToDefaults(userId) {
                 'SELECT COUNT(*)::int AS n FROM user_categories WHERE user_id = $1',
                 [userId]
             );
-            const headroom = Math.max(0, MAX_CATEGORIES_PER_USER - countRows[0].n);
+            const currentCount = countRows[0].n;
+            // Keep an unclamped raw value so callers can compute the true
+            // required-delete count even for grandfathered users where
+            // currentCount > MAX_CATEGORIES_PER_USER (rawHeadroom < 0).
+            const rawHeadroom = MAX_CATEGORIES_PER_USER - currentCount;
+            const headroom = Math.max(0, rawHeadroom);
             if (missingCount > headroom) {
-                const e = new Error(`User ${userId} cannot restore ${missingCount} default(s); only ${headroom} slot(s) available under the ${MAX_CATEGORIES_PER_USER}-category cap.`);
+                const requiredDeletes = missingCount - rawHeadroom;
+                const e = new Error(`User ${userId} cannot restore ${missingCount} default(s); delete at least ${requiredDeletes} category(ies) to fit under the ${MAX_CATEGORIES_PER_USER}-category cap.`);
                 e.code = CATEGORY_CAP_ERROR_CODE;
                 e.missingCount = missingCount;
                 e.headroom = headroom;
+                e.currentCount = currentCount;
+                e.max = MAX_CATEGORIES_PER_USER;
+                e.requiredDeletes = requiredDeletes;
                 throw e;
             }
         }
@@ -1100,9 +1109,9 @@ async function ensurePartnerCategories(userId, partnerId, month) {
 async function _insertImportedPartnerRows(userId, partnerId, rows) {
     const candidates = rows.filter(r => !DEFAULT_CATEGORY_SLUGS.has(r.slug));
     if (candidates.length === 0) return 0;
-    // Sort deterministically before truncation so two near-cap callers
-    // (e.g. simultaneous month switches) always pick the same subset.
-    candidates.sort((a, b) => a.slug.localeCompare(b.slug));
+    const slugs = candidates.map(r => r.slug);
+    const labels = candidates.map(r => r.label || r.slug);
+    const colors = candidates.map(r => r.color || '#94a3b8');
     // Wrap count + insert in a transaction with a per-user advisory lock
     // so concurrent POST /api/categories / AI auto-create / partner
     // imports cannot collectively push the user past MAX_CATEGORIES_PER_USER.
@@ -1110,23 +1119,6 @@ async function _insertImportedPartnerRows(userId, partnerId, rows) {
     try {
         await client.query('BEGIN');
         await client.query('SELECT pg_advisory_xact_lock($1)', [userId]);
-        // Re-filter against current DB state inside the lock. The caller
-        // computed `rows` outside the lock, so by now another importer
-        // / POST / AI call may have inserted some of the candidate
-        // slugs. Without this re-check, a naive slice(0, headroom)
-        // could include already-present slugs (no-ops via ON CONFLICT)
-        // while skipping later still-missing slugs that would have fit.
-        const { rows: existingRows } = await client.query(
-            `SELECT slug FROM user_categories
-             WHERE user_id = $1 AND slug = ANY($2::text[])`,
-            [userId, candidates.map(r => r.slug)]
-        );
-        const existingSet = new Set(existingRows.map(r => r.slug));
-        const importable = candidates.filter(r => !existingSet.has(r.slug));
-        if (importable.length === 0) {
-            await client.query('ROLLBACK');
-            return 0;
-        }
         const { rows: countRows } = await client.query(
             'SELECT COUNT(*)::int AS n FROM user_categories WHERE user_id = $1',
             [userId]
@@ -1134,33 +1126,47 @@ async function _insertImportedPartnerRows(userId, partnerId, rows) {
         const headroom = Math.max(0, MAX_CATEGORIES_PER_USER - countRows[0].n);
         if (headroom === 0) {
             await client.query('ROLLBACK');
-            console.warn(`partner sync truncated for user ${userId}: ${importable.length} tag(s) skipped to stay under ${MAX_CATEGORIES_PER_USER}-category cap`);
+            console.warn(`partner sync truncated for user ${userId}: ${slugs.length} tag(s) skipped to stay under ${MAX_CATEGORIES_PER_USER}-category cap`);
             return 0;
         }
-        let toInsert = importable;
-        if (importable.length > headroom) {
-            console.warn(`partner sync truncated for user ${userId}: ${importable.length - headroom} of ${importable.length} tag(s) skipped to stay under ${MAX_CATEGORIES_PER_USER}-category cap`);
-            toInsert = importable.slice(0, headroom);
-        }
-        const values = [];
-        const insertParams = [userId, partnerId];
-        let i = 3;
-        for (const r of toInsert) {
-            const label = r.label || r.slug;
-            const color = r.color || '#94a3b8';
-            values.push(`($1, $${i++}, $${i++}, $${i++}, FALSE, 998, $2)`);
-            insertParams.push(r.slug, label, color);
-        }
+        // Single-statement: re-filter against current DB state (concurrent
+        // writers may have inserted some candidate slugs since the caller
+        // computed `rows` outside the lock), deterministic ORDER BY slug,
+        // LIMIT to headroom, then INSERT. Lets Postgres do the sort and
+        // truncation instead of materializing/sorting the full candidate
+        // list in JS — important when a partner has a runaway tag set.
         const { rows: insertedRows } = await client.query(
-            `INSERT INTO user_categories
-             (user_id, slug, label, color, is_default, sort_order, imported_from_user_id)
-             VALUES ${values.join(', ')}
-             ON CONFLICT (user_id, slug) DO NOTHING
-             RETURNING slug`,
-            insertParams
+            `WITH cand AS (
+                SELECT slug, label, color
+                FROM unnest($3::text[], $4::text[], $5::text[])
+                  AS t(slug, label, color)
+            ),
+            eligible AS (
+                SELECT c.slug, c.label, c.color
+                FROM cand c
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM user_categories uc
+                    WHERE uc.user_id = $1 AND uc.slug = c.slug
+                )
+                ORDER BY c.slug
+                LIMIT $6
+            )
+            INSERT INTO user_categories
+                (user_id, slug, label, color, is_default, sort_order, imported_from_user_id)
+            SELECT $1, slug, label, color, FALSE, 998, $2 FROM eligible
+            ON CONFLICT (user_id, slug) DO NOTHING
+            RETURNING slug`,
+            [userId, partnerId, slugs, labels, colors, headroom]
         );
+        const inserted = insertedRows.length;
+        if (inserted < slugs.length) {
+            // Skipped = candidates already present (race winners) + truncated
+            // by headroom. We log the gross skip for visibility; the precise
+            // breakdown isn't needed for operational debugging.
+            console.warn(`partner sync for user ${userId}: ${inserted} inserted, ${slugs.length - inserted} skipped (cap=${MAX_CATEGORIES_PER_USER}, headroom=${headroom})`);
+        }
         await client.query('COMMIT');
-        return insertedRows.length;
+        return inserted;
     } catch (e) {
         try { await client.query('ROLLBACK'); } catch (_) { /* ignore */ }
         throw e;

--- a/db/queries.js
+++ b/db/queries.js
@@ -837,6 +837,21 @@ const DEFAULT_CATEGORIES = [
 
 const DEFAULT_CATEGORY_SLUGS = new Set(DEFAULT_CATEGORIES.map(c => c.slug));
 
+// Maximum number of category rows allowed per user. Enforced across
+// every code path that can create a row (POST /api/categories, AI
+// editEntry auto-create, partner import). Defaults are included in
+// the count — but resetUserCategoriesToDefaults can never push a
+// user over the cap because it only upserts the 17 canonical slugs.
+const MAX_CATEGORIES_PER_USER = 100;
+
+async function countUserCategories(userId) {
+    const { rows } = await pool.query(
+        'SELECT COUNT(*)::int AS n FROM user_categories WHERE user_id = $1',
+        [userId]
+    );
+    return rows[0].n;
+}
+
 function dbRowToUserCategory(row) {
     if (!row) return null;
     return {
@@ -894,6 +909,48 @@ async function addUserCategory(userId, { slug, label, color, sortOrder }) {
         [userId, slug, label, color, sortOrder != null ? sortOrder : 999]
     );
     return dbRowToUserCategory(rows[0]);
+}
+
+// Sentinel error thrown by addUserCategoryAtomicWithCap when the user is
+// at or over MAX_CATEGORIES_PER_USER. Callers (POST /api/categories,
+// AI editEntry auto-create) recognize this code to surface a 409 / break
+// out of their loop without leaking transactional details to the user.
+const CATEGORY_CAP_ERROR_CODE = 'CATEGORY_CAP_EXCEEDED';
+
+// Atomic add: takes a per-user advisory lock for the duration of the
+// transaction so concurrent POSTs / AI calls cannot both see headroom
+// and both insert (TOCTOU). The advisory lock is keyed on userId, so
+// it serializes only category writes for that single user — partner
+// writes against a different userId do not contend.
+async function addUserCategoryAtomicWithCap(userId, { slug, label, color, sortOrder }) {
+    const client = await pool.connect();
+    try {
+        await client.query('BEGIN');
+        await client.query('SELECT pg_advisory_xact_lock($1)', [userId]);
+        const { rows: countRows } = await client.query(
+            'SELECT COUNT(*)::int AS n FROM user_categories WHERE user_id = $1',
+            [userId]
+        );
+        if (countRows[0].n >= MAX_CATEGORIES_PER_USER) {
+            await client.query('ROLLBACK');
+            const e = new Error(`User ${userId} is at the per-user category cap (${MAX_CATEGORIES_PER_USER}).`);
+            e.code = CATEGORY_CAP_ERROR_CODE;
+            throw e;
+        }
+        const { rows } = await client.query(
+            `INSERT INTO user_categories (user_id, slug, label, color, is_default, sort_order)
+             VALUES ($1, $2, $3, $4, FALSE, $5)
+             RETURNING *`,
+            [userId, slug, label, color, sortOrder != null ? sortOrder : 999]
+        );
+        await client.query('COMMIT');
+        return dbRowToUserCategory(rows[0]);
+    } catch (e) {
+        try { await client.query('ROLLBACK'); } catch (_) { /* ignore */ }
+        throw e;
+    } finally {
+        client.release();
+    }
 }
 
 // PATCH — defaults can only have color/sort_order updated; label is locked
@@ -1006,24 +1063,56 @@ async function ensurePartnerCategories(userId, partnerId, month) {
 async function _insertImportedPartnerRows(userId, partnerId, rows) {
     const importable = rows.filter(r => !DEFAULT_CATEGORY_SLUGS.has(r.slug));
     if (importable.length === 0) return 0;
-    const values = [];
-    const insertParams = [userId, partnerId];
-    let i = 3;
-    for (const r of importable) {
-        const label = r.label || r.slug;
-        const color = r.color || '#94a3b8';
-        values.push(`($1, $${i++}, $${i++}, $${i++}, FALSE, 998, $2)`);
-        insertParams.push(r.slug, label, color);
+    // Sort deterministically before truncation so two near-cap callers
+    // (e.g. simultaneous month switches) always pick the same subset.
+    importable.sort((a, b) => a.slug.localeCompare(b.slug));
+    // Wrap count + insert in a transaction with a per-user advisory lock
+    // so concurrent POST /api/categories / AI auto-create / partner
+    // imports cannot collectively push the user past MAX_CATEGORIES_PER_USER.
+    const client = await pool.connect();
+    try {
+        await client.query('BEGIN');
+        await client.query('SELECT pg_advisory_xact_lock($1)', [userId]);
+        const { rows: countRows } = await client.query(
+            'SELECT COUNT(*)::int AS n FROM user_categories WHERE user_id = $1',
+            [userId]
+        );
+        const headroom = Math.max(0, MAX_CATEGORIES_PER_USER - countRows[0].n);
+        if (headroom === 0) {
+            await client.query('ROLLBACK');
+            console.warn(`partner sync truncated for user ${userId}: ${importable.length} tag(s) skipped to stay under ${MAX_CATEGORIES_PER_USER}-category cap`);
+            return 0;
+        }
+        let toInsert = importable;
+        if (importable.length > headroom) {
+            console.warn(`partner sync truncated for user ${userId}: ${importable.length - headroom} of ${importable.length} tag(s) skipped to stay under ${MAX_CATEGORIES_PER_USER}-category cap`);
+            toInsert = importable.slice(0, headroom);
+        }
+        const values = [];
+        const insertParams = [userId, partnerId];
+        let i = 3;
+        for (const r of toInsert) {
+            const label = r.label || r.slug;
+            const color = r.color || '#94a3b8';
+            values.push(`($1, $${i++}, $${i++}, $${i++}, FALSE, 998, $2)`);
+            insertParams.push(r.slug, label, color);
+        }
+        const { rows: insertedRows } = await client.query(
+            `INSERT INTO user_categories
+             (user_id, slug, label, color, is_default, sort_order, imported_from_user_id)
+             VALUES ${values.join(', ')}
+             ON CONFLICT (user_id, slug) DO NOTHING
+             RETURNING slug`,
+            insertParams
+        );
+        await client.query('COMMIT');
+        return insertedRows.length;
+    } catch (e) {
+        try { await client.query('ROLLBACK'); } catch (_) { /* ignore */ }
+        throw e;
+    } finally {
+        client.release();
     }
-    const { rows: insertedRows } = await pool.query(
-        `INSERT INTO user_categories
-         (user_id, slug, label, color, is_default, sort_order, imported_from_user_id)
-         VALUES ${values.join(', ')}
-         ON CONFLICT (user_id, slug) DO NOTHING
-         RETURNING slug`,
-        insertParams
-    );
-    return insertedRows.length;
 }
 async function importPartnerCategoriesFromTags(userId, partnerId, slugs) {
     if (!partnerId || !Array.isArray(slugs) || slugs.length === 0) return 0;
@@ -1105,10 +1194,14 @@ module.exports = {
     // User Categories (issue #70)
     DEFAULT_CATEGORIES,
     DEFAULT_CATEGORY_SLUGS,
+    MAX_CATEGORIES_PER_USER,
+    CATEGORY_CAP_ERROR_CODE,
+    countUserCategories,
     getUserCategories,
     getUserCategorySlugs,
     seedDefaultCategoriesForUser,
     addUserCategory,
+    addUserCategoryAtomicWithCap,
     updateUserCategory,
     deleteUserCategory,
     resetUserCategoriesToDefaults,

--- a/db/queries.js
+++ b/db/queries.js
@@ -1098,11 +1098,11 @@ async function ensurePartnerCategories(userId, partnerId, month) {
 // already has the defaults seeded by the caller) and returns the
 // number of rows actually inserted.
 async function _insertImportedPartnerRows(userId, partnerId, rows) {
-    const importable = rows.filter(r => !DEFAULT_CATEGORY_SLUGS.has(r.slug));
-    if (importable.length === 0) return 0;
+    const candidates = rows.filter(r => !DEFAULT_CATEGORY_SLUGS.has(r.slug));
+    if (candidates.length === 0) return 0;
     // Sort deterministically before truncation so two near-cap callers
     // (e.g. simultaneous month switches) always pick the same subset.
-    importable.sort((a, b) => a.slug.localeCompare(b.slug));
+    candidates.sort((a, b) => a.slug.localeCompare(b.slug));
     // Wrap count + insert in a transaction with a per-user advisory lock
     // so concurrent POST /api/categories / AI auto-create / partner
     // imports cannot collectively push the user past MAX_CATEGORIES_PER_USER.
@@ -1110,6 +1110,23 @@ async function _insertImportedPartnerRows(userId, partnerId, rows) {
     try {
         await client.query('BEGIN');
         await client.query('SELECT pg_advisory_xact_lock($1)', [userId]);
+        // Re-filter against current DB state inside the lock. The caller
+        // computed `rows` outside the lock, so by now another importer
+        // / POST / AI call may have inserted some of the candidate
+        // slugs. Without this re-check, a naive slice(0, headroom)
+        // could include already-present slugs (no-ops via ON CONFLICT)
+        // while skipping later still-missing slugs that would have fit.
+        const { rows: existingRows } = await client.query(
+            `SELECT slug FROM user_categories
+             WHERE user_id = $1 AND slug = ANY($2::text[])`,
+            [userId, candidates.map(r => r.slug)]
+        );
+        const existingSet = new Set(existingRows.map(r => r.slug));
+        const importable = candidates.filter(r => !existingSet.has(r.slug));
+        if (importable.length === 0) {
+            await client.query('ROLLBACK');
+            return 0;
+        }
         const { rows: countRows } = await client.query(
             'SELECT COUNT(*)::int AS n FROM user_categories WHERE user_id = $1',
             [userId]

--- a/index.html
+++ b/index.html
@@ -2507,6 +2507,7 @@
                         </div>
                         <button type="button" id="addCategoryBtn" class="add-entry-btn" data-i18n="category.add">Add</button>
                     </div>
+                    <div id="categoryCapNote" role="status" aria-live="polite" hidden style="color: var(--color-text-muted); font-size: 0.85rem; margin-top: 0.5rem;"></div>
                     <div id="categoryFormError" role="alert" style="color: var(--color-accent-danger); font-size: 0.85rem; min-height: 1.2em; margin-top: 0.5rem;"></div>
 
                     <div style="display:flex; justify-content: space-between; align-items: center; margin-top: 1.25rem;">

--- a/js/app.js
+++ b/js/app.js
@@ -1746,7 +1746,9 @@ if (resetCategoriesBtn) {
                 // can't fit). Surface the server's message in the same inline
                 // error area used by Add, and refresh local state so the cap
                 // note reflects current usage.
-                let msg = t('category.resetFailed') || 'Could not restore defaults.';
+                const resetFailedKey = 'category.resetFailed';
+                const resetFailedText = t(resetFailedKey);
+                let msg = resetFailedText === resetFailedKey ? 'Could not restore defaults.' : resetFailedText;
                 try { const body = await res.json(); if (body && body.message) msg = body.message; } catch {}
                 await loadUserCategories();
                 renderCategoryManageList();

--- a/js/app.js
+++ b/js/app.js
@@ -1506,10 +1506,10 @@ function updateCategoryCapState() {
     if (newCategoryLabelInput) newCategoryLabelInput.disabled = atCap;
     if (newCategoryColorInput) newCategoryColorInput.disabled = atCap;
     if (atCap) {
-        const tpl = t('category.capReached') || '{used} / {max} categories used. Delete one to add another.';
-        categoryCapNote.textContent = tpl
-            .replace('{used}', String(used))
-            .replace('{max}', String(MAX_CATEGORIES_PER_USER_FE));
+        categoryCapNote.textContent = t('category.capReached', {
+            used: String(used),
+            max: String(MAX_CATEGORIES_PER_USER_FE)
+        });
         categoryCapNote.hidden = false;
     } else {
         categoryCapNote.textContent = '';
@@ -1741,6 +1741,16 @@ if (resetCategoriesBtn) {
                 renderCategoryChips();
                 syncHiddenCategorySelect();
                 filterEntries({ resetPage: false });
+            } else if (res.status === 409) {
+                // Restoring would push the user past the cap (deleted defaults
+                // can't fit). Surface the server's message in the same inline
+                // error area used by Add, and refresh local state so the cap
+                // note reflects current usage.
+                let msg = t('category.resetFailed') || 'Could not restore defaults.';
+                try { const body = await res.json(); if (body && body.message) msg = body.message; } catch {}
+                await loadUserCategories();
+                renderCategoryManageList();
+                setCatFormError(msg);
             }
         } catch (e) { console.error(e); }
     });

--- a/js/app.js
+++ b/js/app.js
@@ -36,6 +36,11 @@ const ORPHAN_CATEGORY_COLOR = '#94a3b8';
 function setUserCategories(list) {
     userCategories = Array.isArray(list) ? list : [];
     _userCategoriesBySlug = new Map(userCategories.map(c => [c.slug, c]));
+    // Keep the manage-modal cap state in sync with any background mutation
+    // (partner imports during loadEntries, AI auto-create, restore-defaults
+    // from another tab, etc.). updateCategoryCapState() is a no-op when
+    // the modal DOM isn't present yet, so it's cheap to call here.
+    if (typeof updateCategoryCapState === 'function') updateCategoryCapState();
 }
 
 function categoryColor(slug) {
@@ -1478,13 +1483,43 @@ const newCategoryColorInput = document.getElementById('newCategoryColor');
 const addCategoryBtn = document.getElementById('addCategoryBtn');
 const resetCategoriesBtn = document.getElementById('resetCategoriesBtn');
 const categoryFormError = document.getElementById('categoryFormError');
+const categoryCapNote = document.getElementById('categoryCapNote');
+
+// Mirrors db.MAX_CATEGORIES_PER_USER on the server. Kept in sync manually
+// — the server is the source of truth (POST /api/categories returns 409
+// regardless), so a stale FE value is degraded UX, never a security gap.
+const MAX_CATEGORIES_PER_USER_FE = 100;
 
 function setCatFormError(msg) {
     if (categoryFormError) categoryFormError.textContent = msg || '';
 }
 
+// Reflect the per-user cap in the manage modal: disable the Add button +
+// inputs when at/over cap, and show a small inline note. Called from
+// renderCategoryManageList so the state stays in sync with userCategories.
+function updateCategoryCapState() {
+    if (!addCategoryBtn || !categoryCapNote) return;
+    const used = userCategories.length;
+    const atCap = used >= MAX_CATEGORIES_PER_USER_FE;
+    addCategoryBtn.disabled = atCap;
+    if (newCategorySlugInput) newCategorySlugInput.disabled = atCap;
+    if (newCategoryLabelInput) newCategoryLabelInput.disabled = atCap;
+    if (newCategoryColorInput) newCategoryColorInput.disabled = atCap;
+    if (atCap) {
+        const tpl = t('category.capReached') || '{used} / {max} categories used. Delete one to add another.';
+        categoryCapNote.textContent = tpl
+            .replace('{used}', String(used))
+            .replace('{max}', String(MAX_CATEGORIES_PER_USER_FE));
+        categoryCapNote.hidden = false;
+    } else {
+        categoryCapNote.textContent = '';
+        categoryCapNote.hidden = true;
+    }
+}
+
 function renderCategoryManageList() {
     if (!categoryListBody) return;
+    updateCategoryCapState();
     categoryListBody.innerHTML = '';
     if (userCategories.length === 0) {
         const tr = document.createElement('tr');
@@ -1670,6 +1705,14 @@ if (addCategoryBtn) {
             if (!res.ok) {
                 let msg = t('category.addFailed') || 'Failed to add category.';
                 try { const body = await res.json(); if (body && (body.message || body.error)) msg = body.message || body.error; } catch {}
+                // Refresh local state so the cap note + button-disabled state
+                // reflect any concurrent mutation that caused the 409 (e.g.
+                // a partner import pushed us past the cap between the modal
+                // opening and the click).
+                if (res.status === 409) {
+                    await loadUserCategories();
+                    renderCategoryManageList();
+                }
                 setCatFormError(msg);
                 return;
             }

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -79,6 +79,7 @@ const translations = {
     'category.deleteConfirm': 'Delete this category? Existing entries keep the tag but will render as orphans.',
     'category.resetConfirm': 'Restore the default categories? Your custom categories will be kept.',
     'category.addFailed': 'Failed to add category.',
+    'category.capReached': '{used} / {max} categories used. Delete one to add another.',
 
     // ── Dashboard header ──
     'dash.addEntry': 'Add New Entry',
@@ -639,6 +640,7 @@ const translations = {
     'category.deleteConfirm': 'Excluir esta categoria? Os lançamentos existentes manterão a etiqueta como órfã.',
     'category.resetConfirm': 'Restaurar as categorias padrão? Suas categorias personalizadas serão mantidas.',
     'category.addFailed': 'Não foi possível adicionar a categoria.',
+    'category.capReached': '{used} / {max} categorias em uso. Apague uma para adicionar outra.',
 
     // ── Dashboard header ──
     'dash.addEntry': 'Nova Entrada',

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -79,6 +79,7 @@ const translations = {
     'category.deleteConfirm': 'Delete this category? Existing entries keep the tag but will render as orphans.',
     'category.resetConfirm': 'Restore the default categories? Your custom categories will be kept.',
     'category.addFailed': 'Failed to add category.',
+    'category.resetFailed': 'Could not restore defaults.',
     'category.capReached': '{used} / {max} categories used. Delete one to add another.',
 
     // ── Dashboard header ──
@@ -640,6 +641,7 @@ const translations = {
     'category.deleteConfirm': 'Excluir esta categoria? Os lançamentos existentes manterão a etiqueta como órfã.',
     'category.resetConfirm': 'Restaurar as categorias padrão? Suas categorias personalizadas serão mantidas.',
     'category.addFailed': 'Não foi possível adicionar a categoria.',
+    'category.resetFailed': 'Não foi possível restaurar as categorias padrão.',
     'category.capReached': '{used} / {max} categorias em uso. Apague uma para adicionar outra.',
 
     // ── Dashboard header ──

--- a/server.js
+++ b/server.js
@@ -2392,12 +2392,18 @@ app.post('/api/categories', requireAuth, asyncHandler(async (req, res) => {
         return res.status(409).json({ message: 'That slug is reserved for a default category. Use Restore Defaults to bring it back.' });
     }
     // Ensure defaults exist (so a brand-new account adding a custom category
-    // first still gets the seeded defaults afterward via GET).
+    // first still gets the seeded defaults afterward via GET). The atomic
+    // helper below also enforces the per-user cap (defaults included)
+    // inside a single transaction with a per-user advisory lock, so
+    // concurrent requests cannot collectively exceed it.
     await getCategoriesForUserSelfHeal(req.user.id);
     try {
-        const created = await db.addUserCategory(req.user.id, { slug: normSlug, label: normLabel, color: normColor });
+        const created = await db.addUserCategoryAtomicWithCap(req.user.id, { slug: normSlug, label: normLabel, color: normColor });
         res.status(201).json(created);
     } catch (e) {
+        if (e && e.code === db.CATEGORY_CAP_ERROR_CODE) {
+            return res.status(409).json({ message: `That would exceed the per-user category limit of ${db.MAX_CATEGORIES_PER_USER}. Delete an existing category to add another.` });
+        }
         if (e && e.code === '23505') {
             return res.status(409).json({ message: 'A category with that slug already exists.' });
         }
@@ -3755,6 +3761,13 @@ async function validateEditArgs(userId, args) {
         const known = new Set(userCats);
         if (userCats.length > 0) {
             const AUTOCREATE_CAP = 3;
+            // Honor the per-user category cap: even if AUTOCREATE_CAP would
+            // allow up to 3 new rows, never push the user past the global
+            // limit. headroom is computed against the live count and the
+            // atomic helper re-checks under a per-user advisory lock so
+            // concurrent paths cannot collectively exceed the cap.
+            const headroom = Math.max(0, db.MAX_CATEGORIES_PER_USER - userCats.length);
+            const perCallCap = Math.min(AUTOCREATE_CAP, headroom);
             const toCreate = [];
             for (const t of wellFormed) {
                 if (known.has(t)) continue;
@@ -3765,15 +3778,18 @@ async function validateEditArgs(userId, args) {
                 // rather than getting silently re-created as a non-default row
                 // that would corrupt label translation/locking.
                 if (db.DEFAULT_CATEGORY_SLUGS.has(t)) continue;
-                if (toCreate.length >= AUTOCREATE_CAP) break;
+                if (toCreate.length >= perCallCap) break;
                 toCreate.push(t);
                 known.add(t);
             }
             for (const slug of toCreate) {
                 try {
-                    await db.addUserCategory(userId, { slug, label: slug, color: '#94a3b8' });
+                    await db.addUserCategoryAtomicWithCap(userId, { slug, label: slug, color: '#94a3b8' });
                     autoCreatedTags.push(slug);
-                } catch (_) { /* already exists race — ignore */ }
+                } catch (e) {
+                    if (e && e.code === db.CATEGORY_CAP_ERROR_CODE) break; // cap reached mid-loop (concurrent writer); stop creating
+                    /* already exists race or other transient error — ignore */
+                }
             }
         }
         updates.tags = wellFormed;

--- a/server.js
+++ b/server.js
@@ -2458,8 +2458,17 @@ app.post('/api/categories/reset-defaults', requireAuth, asyncHandler(async (req,
         res.json(cats);
     } catch (e) {
         if (e && e.code === db.CATEGORY_CAP_ERROR_CODE) {
+            // Prefer the typed `requiredDeletes` from the DB layer (handles
+            // the grandfathered case where currentCount > MAX). Fall back
+            // through `currentCount` derivation, then to the clamped
+            // headroom subtraction, then to a generic message.
+            const requiredDeletes = Number.isFinite(e.requiredDeletes)
+                ? e.requiredDeletes
+                : Number.isFinite(e.currentCount) && Number.isFinite(e.missingCount)
+                    ? Math.max(0, e.currentCount + e.missingCount - db.MAX_CATEGORIES_PER_USER)
+                    : Math.max(0, (e.missingCount || 0) - (e.headroom || 0));
             return res.status(409).json({
-                message: `Restoring defaults would exceed the per-user category limit of ${db.MAX_CATEGORIES_PER_USER}. Delete ${e.missingCount - e.headroom} more category(ies) first.`
+                message: `Restoring defaults would exceed the per-user category limit of ${db.MAX_CATEGORIES_PER_USER}. Delete ${requiredDeletes} more category(ies) first.`
             });
         }
         throw e;

--- a/server.js
+++ b/server.js
@@ -2453,8 +2453,17 @@ app.delete('/api/categories/:slug', requireAuth, asyncHandler(async (req, res) =
 }));
 
 app.post('/api/categories/reset-defaults', requireAuth, asyncHandler(async (req, res) => {
-    const cats = await db.resetUserCategoriesToDefaults(req.user.id);
-    res.json(cats);
+    try {
+        const cats = await db.resetUserCategoriesToDefaults(req.user.id);
+        res.json(cats);
+    } catch (e) {
+        if (e && e.code === db.CATEGORY_CAP_ERROR_CODE) {
+            return res.status(409).json({
+                message: `Restoring defaults would exceed the per-user category limit of ${db.MAX_CATEGORIES_PER_USER}. Delete ${e.missingCount - e.headroom} more category(ies) first.`
+            });
+        }
+        throw e;
+    }
 }));
 
 // ============ ADMIN ENDPOINTS ============


### PR DESCRIPTION
Closes #73.

## What

Enforces a per-user maximum of **100 `user_categories` rows** (defaults included) across every code path that can create one, with TOCTOU-safe atomicity.

## Backend

| Path | Behavior at cap |
|---|---|
| `POST /api/categories` | 409 `{ message: "That would exceed the per-user category limit of 100. Delete an existing category to add another." }` |
| AI `editEntry` auto-create (`validateEditArgs`) | `perCallCap = min(AUTOCREATE_CAP=3, headroom)`; loop also breaks early if a concurrent writer pushes us over mid-call |
| Partner import (`ensurePartnerCategories` + `importPartnerCategoriesFromTags` → shared `_insertImportedPartnerRows`) | importable list re-checked against current DB state inside the lock, sorted deterministically, then truncated to fit headroom; server-side `console.warn` logs the truncation |
| `POST /api/categories/reset-defaults` (`resetUserCategoriesToDefaults`) | Cap-aware. Restoring defaults that the user previously deleted is an INSERT and counts toward the cap. If `missingCount > headroom`, returns 409 with a precise message (`Restoring defaults would exceed the per-user category limit of 100. Delete N more category(ies) first.`). Defaults already present remain a pure UPDATE and never blocked. |

### Atomicity (TOCTOU fix)

A naive `count` → `INSERT` pattern has a window where two concurrent requests can both see headroom and both insert, pushing past 100. Fixed by adding **`addUserCategoryAtomicWithCap(userId, ...)`**: wraps count + insert in a single transaction guarded by **`pg_advisory_xact_lock(userId)`**, serializing category writes for that one user. The shared partner-import helper and `resetUserCategoriesToDefaults` use the same lock pattern. Writes against a different `userId` do not contend.

A typed sentinel **`CATEGORY_CAP_ERROR_CODE = 'CATEGORY_CAP_EXCEEDED'`** is thrown on cap rejection so callers can distinguish it from generic insert failures (e.g. unique-violation `23505`). Reset-defaults additionally attaches `missingCount` and `headroom` to the error so the endpoint can compose a precise message.

## Frontend

- New i18n keys **`category.capReached`** and **`category.resetFailed`** (EN + PT).
- **`updateCategoryCapState()`** disables the **Add** button and the slug/label/color inputs and shows an inline note (`{used} / {max} categories used. Delete one to add another.`) using `t()` placeholder interpolation when at cap.
- Hooked into **`setUserCategories`** so any background mutation (partner imports during `loadEntries`, AI auto-create, restore-defaults triggered from another tab) auto-refreshes the modal state.
- A 409 from **Add** reloads `userCategories` before surfacing the error so the modal reflects the post-mutation truth.
- A 409 from **Restore defaults** reloads `userCategories` and surfaces the server's precise message inline (same error area as Add).

The FE limit constant (`MAX_CATEGORIES_PER_USER_FE = 100`) is kept in sync manually with `db.MAX_CATEGORIES_PER_USER`. Server is the source of truth — a stale FE value is degraded UX, never a bypass.

## Testing notes

Manual scenarios validated:
- Add the 84th custom (defaults already at 17 → total = 100): button disables, note appears, server returns 409.
- Delete one: cap state clears, controls re-enable.
- Partner import that would push past 100: only `headroom` rows imported, warning logged, entries still load.
- AI `editEntry` with 5 new tags when only 1 slot remains: 1 created, rest left as orphans.
- Delete several defaults, fill cap with custom categories, then click Restore defaults: 409 with "Delete N more category(ies) first." surfaced inline.

## Out of scope

- No retroactive trim — users who somehow already exceed 100 (impossible today) are grandfathered.
- No per-couple shared cap — each user has their own 100-row budget.
- Migration & deployment require no DB schema change.
