### PR TITLE
chore: add Sponsor button (.github/FUNDING.yml → PayPal)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,4 +1,5 @@
 # Renders the "❤️ Sponsor" button at the top of the repository page.
 # Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
 custom:
+  - https://www.paypal.com/webapps/billing/plans/subscribe?plan_id=P-9FK55993FG2877321NHV26GQ
   - https://www.paypal.com/ncp/payment/MV7WU2MHKP3P4

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# Renders the "❤️ Sponsor" button at the top of the repository page.
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/displaying-a-sponsor-button-in-your-repository
+custom:
+  - https://www.paypal.com/ncp/payment/MV7WU2MHKP3P4


### PR DESCRIPTION
Adds `.github/FUNDING.yml` with a `custom:` entry pointing at the project's PayPal No-Code Payment checkout (`https://www.paypal.com/ncp/payment/MV7WU2MHKP3P4`). GitHub auto-renders this as a '❤️ Sponsor' button at the top of the repo page once the file lands on `main`.

No code changes. After merge, also confirm Settings → General → Features → **Sponsorships** is enabled (it is by default for public repos).