### PR TITLE
docs(README): add 'Support this project' section with PayPal buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If Asset Manager saves you time, please consider supporting development:
 - 🔁 **Monthly subscription** — recurring support keeps the project sustainable.
 - ☕ **One-time donation** — fund a feature, a beer, or a coffee.
 
-All sponsors are listed in the [release notes](../../releases) (opt-in).
+All sponsors are listed in the [release notes](https://github.com/fdsimoes-git/asset-management/releases) (opt-in).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,18 @@
 
 A secure multi-user web-based asset management system with AI-powered expense tracking that automatically processes financial documents and provides personalized financial advice through an AI chat advisor. Supports four AI providers: Google Gemini, OpenAI, Anthropic Claude (API key **or** Claude Code OAuth subscription), and GitHub Copilot (OAuth subscription).
 
+## 💖 Support this project
+
+If Asset Manager saves you time, please consider supporting development:
+
+[![Sponsor monthly](https://img.shields.io/badge/PayPal-Subscribe%20monthly-0070ba?logo=paypal&logoColor=white&style=for-the-badge)](https://www.paypal.com/webapps/billing/plans/subscribe?plan_id=P-9FK55993FG2877321NHV26GQ)
+[![One-time donation](https://img.shields.io/badge/PayPal-One--time%20donation-003087?logo=paypal&logoColor=white&style=for-the-badge)](https://www.paypal.com/ncp/payment/MV7WU2MHKP3P4)
+
+- 🔁 **Monthly subscription** — recurring support keeps the project sustainable.
+- ☕ **One-time donation** — fund a feature, a beer, or a coffee.
+
+All sponsors are listed in the [release notes](../../releases) (opt-in).
+
 ## Features
 
 ### Core Functionality


### PR DESCRIPTION
Adds a `�� Support this project` section right under the project description, with two big PayPal-blue shields.io badge buttons linking to the recurring subscription and the one-time donation URLs already in `.github/FUNDING.yml`.

The native Sponsor dropdown on the repo page can only render `custom:` URLs as plain text — no images, no descriptions. This README section gives the same two PayPal links a much more inviting visual presentation with per-link explanations.

Pure docs change. `FUNDING.yml` is unchanged.