### PR TITLE
fix(server): stop serving project root via express.static (#82)

### DIFF
--- a/server.js
+++ b/server.js
@@ -929,13 +929,16 @@ Object.entries(htmlPages).forEach(([route, file]) => {
     });
 });
 
-app.use(express.static(__dirname, {
+// Only the /js directory is served statically. Every HTML page is rendered
+// through an explicit route above (htmlPages), and there are no other
+// browser-served assets at the project root. Mounting express.static at
+// __dirname previously exposed server.js, config.js, db/*, package*.json
+// and node_modules/** to anonymous GET requests (CodeQL alert #5).
+app.use('/js', express.static(path.join(__dirname, 'js'), {
     maxAge: '1h',
-    setHeaders: (res, filePath) => {
-        if (path.extname(filePath).toLowerCase() === '.html') {
-            res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
-        }
-    }
+    dotfiles: 'deny',
+    index: false,
+    redirect: false
 }));
 
 // Trust Nginx proxy


### PR DESCRIPTION
Closes #82 · Resolves CodeQL alert [#5](https://github.com/fdsimoes-git/asset-management/security/code-scanning/5) (CWE-200 / CWE-219 / CWE-548).

## Reality check on the original issue

The issue (and CodeQL) implied that `server.js`, `config.js`, `db/*`, `package.json`, `node_modules/**` and the ops scripts were all anonymously fetchable. **They weren't on `main`** — there's an existing allowlist/blocker middleware at `server.js:872-890` that already 404s those exact paths before `express.static` runs.

What was *actually* leaking at the project root (verified with curl against `origin/main`):

| Path | Before | After |
|---|---|---|
| `/CLAUDE.md` | **200** | **404** |
| `/README.md` | 200 | 404 (intentionally public on GitHub anyway) |
| `/LICENSE` | 200 | 404 (intentionally public on GitHub anyway) |
| `/server.js`, `/config.js`, `/package.json`, `/package-lock.json`, `/db/*`, `/node_modules/*`, `/backup.sh`, `/deploy.sh`, `/rotate-key.sh`, `/rotate-encryption-key.js`, `/capacitor.config.json` | already 404 (blocker) | 404 |
| `/.env`, `/.env.example`, `/.gitignore` | already 404 (Express `dotfiles: 'ignore'`) | 404 |

So the immediate, exploitable leak was just `CLAUDE.md`. The deeper problem is the **architecture**: `express.static(__dirname)` defends by blocklist — every new top-level file silently becomes web-fetchable until someone remembers to update the deny list.

## Fix

Flip from blocklist to **allowlist**: only `/js` is statically mounted, since that's the only directory the browser consumes (every HTML page is already pre-rendered through an explicit route — `htmlPages` at `server.js:899-930` — and there are no favicons / manifest / css / service-worker assets at the root).

```diff
-app.use(express.static(__dirname, {
-    maxAge: '1h',
-    setHeaders: (res, filePath) => {
-        if (path.extname(filePath).toLowerCase() === '.html') {
-            res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
-        }
-    }
-}));
+app.use('/js', express.static(path.join(__dirname, 'js'), {
+    maxAge: '1h',
+    dotfiles: 'deny',
+    index: false,
+    redirect: false
+}));
```

The `setHeaders` HTML override was already dead code — every `*.html` request hit the explicit route ahead of `express.static`.

The pre-existing sensitive-files blocker (`server.js:872-890`) is **kept as defense-in-depth**: it costs ~one regex + one `.some()` per request and acts as a safety net if anyone ever broadens the static mount, adds another `express.static`, or introduces a path-handling route from user input.

## Verification

Manual curl against `node server.js` on a local port (after the fix):

```
404  /server.js
404  /config.js
404  /package.json
404  /db/queries.js
404  /node_modules/express/package.json
404  /backup.sh
404  /CLAUDE.md
404  /README.md
404  /LICENSE
200  /
200  /index.html  /login.html  /register.html  /forgot-password.html
200  /js/{app,chat,csrf,i18n,login,register,forgot-password}.js
```

CodeQL alert #5 should auto-resolve on the next scan.
