### PR TITLE
Use Postgres-backed session store (fix #44)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ All sponsors are listed in the [release notes](https://github.com/fdsimoes-git/a
 
 ## Requirements
 
-- **Node.js** 18.x or higher
+- **Node.js** 18.18+, 20.9+, or 22+ (required by `connect-pg-simple`)
 - **npm** (Node Package Manager)
 - **PostgreSQL** 14+ (localhost, scram-sha-256 auth recommended)
 - **Modern web browser** with JavaScript enabled

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -99,4 +99,27 @@ CREATE INDEX IF NOT EXISTS idx_user_categories_user_id ON user_categories(user_i
 -- ── Idempotent column additions for existing deployments ─────────────
 ALTER TABLE users ADD COLUMN IF NOT EXISTS web_search_enabled BOOLEAN NOT NULL DEFAULT FALSE;
 
+-- ── Session store (connect-pg-simple) ────────────────────────────────
+-- Mirrors node_modules/connect-pg-simple/table.sql verbatim. The store also
+-- creates this table at runtime via createTableIfMissing as a safety net,
+-- but defining it here means fresh installs get it via psql -f schema.sql
+-- and operators with locked-down DB roles can pre-create it explicitly.
+CREATE TABLE IF NOT EXISTS "session" (
+    "sid"    varchar      NOT NULL COLLATE "default",
+    "sess"   json         NOT NULL,
+    "expire" timestamp(6) NOT NULL
+) WITH (OIDS=FALSE);
+
+DO $$ BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'session_pkey'
+    ) THEN
+        ALTER TABLE "session"
+            ADD CONSTRAINT "session_pkey" PRIMARY KEY ("sid")
+            NOT DEFERRABLE INITIALLY IMMEDIATE;
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS "IDX_session_expire" ON "session" ("expire");
+
 COMMIT;

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -108,7 +108,7 @@ CREATE TABLE IF NOT EXISTS "session" (
     "sid"    varchar      NOT NULL COLLATE "default",
     "sess"   json         NOT NULL,
     "expire" timestamp(6) NOT NULL
-) WITH (OIDS=FALSE);
+);
 
 DO $$ BEGIN
     IF NOT EXISTS (

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -107,18 +107,9 @@ ALTER TABLE users ADD COLUMN IF NOT EXISTS web_search_enabled BOOLEAN NOT NULL D
 CREATE TABLE IF NOT EXISTS "session" (
     "sid"    varchar      NOT NULL COLLATE "default",
     "sess"   json         NOT NULL,
-    "expire" timestamp(6) NOT NULL
+    "expire" timestamp(6) NOT NULL,
+    CONSTRAINT "session_pkey" PRIMARY KEY ("sid")
 );
-
-DO $$ BEGIN
-    IF NOT EXISTS (
-        SELECT 1 FROM pg_constraint WHERE conname = 'session_pkey'
-    ) THEN
-        ALTER TABLE "session"
-            ADD CONSTRAINT "session_pkey" PRIMARY KEY ("sid")
-            NOT DEFERRABLE INITIALLY IMMEDIATE;
-    END IF;
-END $$;
 
 CREATE INDEX IF NOT EXISTS "IDX_session_expire" ON "session" ("expire");
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@google/genai": "^1.43.0",
         "@paypal/paypal-server-sdk": "^2.0.0",
         "bcryptjs": "^2.4.3",
+        "connect-pg-simple": "^10.0.0",
         "dotenv": "^16.5.0",
         "express": "^4.18.2",
         "express-rate-limit": "^8.2.1",
@@ -1052,6 +1053,18 @@
         "inherits": "^2.0.3",
         "readable-stream": "^3.0.2",
         "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/connect-pg-simple": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/connect-pg-simple/-/connect-pg-simple-10.0.0.tgz",
+      "integrity": "sha512-pBGVazlqiMrackzCr0eKhn4LO5trJXsOX0nQoey9wCOayh80MYtThCbq8eoLsjpiWgiok/h+1/uti9/2/Una8A==",
+      "license": "MIT",
+      "dependencies": {
+        "pg": "^8.12.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=22.0.0"
       }
     },
     "node_modules/content-disposition": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@google/genai": "^1.43.0",
     "@paypal/paypal-server-sdk": "^2.0.0",
     "bcryptjs": "^2.4.3",
+    "connect-pg-simple": "^10.0.0",
     "dotenv": "^16.5.0",
     "express": "^4.18.2",
     "express-rate-limit": "^8.2.1",

--- a/server.js
+++ b/server.js
@@ -2,6 +2,7 @@
 const config = require('./config');
 const express = require('express');
 const session = require('express-session');
+const PgSession = require('connect-pg-simple')(session);
 const bcrypt = require('bcryptjs');
 const helmet = require('helmet');
 const https = require('https');
@@ -9,7 +10,7 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const db = require('./db/queries');
-const { testConnection: testDbConnection } = require('./db/pool');
+const { pool: dbPool, testConnection: testDbConnection } = require('./db/pool');
 const multer = require('multer'); // For handling file uploads
 const rateLimit = require('express-rate-limit');
 const pdfParse = require('pdf-parse'); // For parsing PDF files
@@ -945,7 +946,16 @@ app.use('/js', express.static(path.join(__dirname, 'js'), {
 app.set('trust proxy', 1);
 
 // Session configuration
+// Persistent Postgres-backed session store. Keeps sessions across restarts and
+// removes the express-session MemoryStore production warning. The `session`
+// table is auto-created on first boot via createTableIfMissing.
 app.use(session({
+    store: new PgSession({
+        pool: dbPool,
+        tableName: 'session',
+        createTableIfMissing: true,
+        pruneSessionInterval: 60 * 15 // seconds; expired-row cleanup
+    }),
     secret: config.sessionSecret,
     resave: false,
     saveUninitialized: false,


### PR DESCRIPTION
Fixes #44.

## Problem

`express-session` was running with the default `MemoryStore`, which:
- prints `Warning: connect.session() MemoryStore is not designed for a production environment...` on every boot,
- leaks memory over time (every active session lives in the Node heap until the cookie expires),
- loses every active session on every restart (so v2.6.4/v2.6.5 deploys logged everyone out), and
- prevents any future horizontal scaling.

## Change

Drop-in `connect-pg-simple` store wired into the existing `pg` pool from `db/pool.js`:

```js
const PgSession = require('connect-pg-simple')(session);
app.use(session({
    store: new PgSession({
        pool: dbPool,
        tableName: 'session',
        createTableIfMissing: true,
        pruneSessionInterval: 60 * 15
    }),
    /* unchanged */
}));
```

### Files touched
- **`server.js`** — wire `PgSession` store into the existing `session(...)` block.
- **`package.json` / `package-lock.json`** — add `connect-pg-simple` (1 new dep, ~30 KB, 0 vulnerabilities).
- **`db/schema.sql`** — append the canonical `session` DDL (mirrors `node_modules/connect-pg-simple/table.sql`) wrapped in idempotent guards. Fresh installs get the table from `psql -f db/schema.sql`; existing prod gets it auto-created on first request via `createTableIfMissing`.
- **`README.md`** — bump Node requirement from "18.x or higher" to `18.18+ / 20.9+ / 22+` to match `connect-pg-simple@10`'s engines field.

No env-var, schema-migration-script, or frontend changes.

## Verification

- `node --check server.js` ✅
- Server boots cleanly: `PostgreSQL connection verified.` then `Server running on https://localhost:3457`. No more MemoryStore warning.
- Drove the store directly to confirm `createTableIfMissing` works:
  ```
  session set OK
  row: [ { sid: 'test-sid-123', expire: 2026-04-25T20:26:11.000Z } ]
  cols: sess,expire,sid
  ```
- Applied the new `db/schema.sql` session block twice in a row against a clean DB — second apply is a no-op. Final state has correct columns, `session_pkey`, and `IDX_session_expire`.

## Deploy notes

```bash
git pull
npm install              # ← new this time (1 new dep: connect-pg-simple)
sudo systemctl restart asset-manager
```

- The `session` table is created automatically on first request after restart.
- All active sessions are invalidated once on cutover (one-time mass re-login). After that sessions persist across restarts.
- Rollback: `git checkout v2.6.5 && npm install && restart`. Leftover `session` table is harmless.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
