### PR TITLE
Refresh CLAUDE.md to match current codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,15 +4,15 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-Secure multi-user asset management web app with AI-powered expense tracking. Node.js/Express backend serving vanilla JavaScript frontend directly (no build step). PostgreSQL database with field-level AES-256-CBC encryption. Supports English and Portuguese (i18n).
+Secure multi-user asset management web app with AI-powered expense tracking. Node.js/Express backend serving vanilla JavaScript frontend directly (no build step). PostgreSQL database with field-level AES-256-CBC encryption and Postgres-backed session storage. Supports English and Portuguese (i18n).
 
 ## Commands
 
 ```bash
-# Install dependencies
+# Install dependencies (Node.js 18.18+, 20.9+, or 22+ required by connect-pg-simple)
 npm install
 
-# Run dev server (port 3000 by default)
+# Run dev server (port 3000 by default; override with PORT env var)
 npm start
 
 # Run production server (port 443, requires sudo)
@@ -21,14 +21,14 @@ npm run start:prod
 # Generate self-signed SSL certificates
 npm run ssl
 
-# Generate bcrypt password hash for admin setup
-npm run hash-password <password>
+# Generate bcrypt password hash for admin setup (note the `--`)
+npm run hash-password -- <password>
 
 # Generate encryption key
 node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 ```
 
-**No test framework, linter, or build step exists.** Frontend JS is served directly to the browser.
+**No test framework, linter, or build step exists.** Frontend JS is served directly to the browser. Use `node --check server.js` for a quick syntax sanity check.
 
 ## Environment Setup
 
@@ -44,48 +44,57 @@ Copy `.env.example` to `.env`. Required variables:
 
 ### Backend (single-file server)
 
-**`server.js`** (~3,400 lines) — monolithic Express app containing all route handlers, middleware, AI integration, and business logic. All 46 API endpoints are defined here.
+**`server.js`** (~5,560 lines) — monolithic Express app containing all route handlers, middleware, AI integration, and business logic. ~60 API endpoints are defined here.
 
 **`config.js`** — centralized env var loading with startup validation. Exports a single config object.
 
 **`db/`** — database layer:
-- `pool.js` — pg connection pool (max 10 connections)
-- `queries.js` — all parameterized SQL query functions (~620 lines)
-- `schema.sql` — PostgreSQL schema (tables: `users`, `entries`, `invite_codes`, `paypal_orders`)
+- `pool.js` — pg connection pool (max 10 connections), exports `{ pool, testConnection }`
+- `queries.js` — all parameterized SQL query functions (~1,270 lines)
+- `schema.sql` — PostgreSQL schema (tables: `users`, `entries`, `user_categories`, `invite_codes`, `paypal_orders`, `session`)
 - `migrate-json-to-pg.js` — one-shot idempotent migration from legacy JSON storage
+- `migrate-add-*.sql` + `MIGRATION_RUNBOOK.md` — incremental schema migrations
 
 ### Frontend (no framework, no build)
 
 All frontend code is vanilla JavaScript loaded directly by the browser:
-- `index.html` (83KB) — main dashboard with inline CSS
-- `js/app.js` (~3,000 lines) — dashboard logic, charts (Chart.js), CRUD, admin panel
-- `js/chat.js` — AI financial advisor floating chat widget
-- `js/i18n.js` (~45,000 lines) — English + Portuguese translations (600+ keys)
+- `index.html` (~110 KB / ~2,840 lines) — main dashboard with inline CSS
+- `js/app.js` (~4,630 lines) — dashboard logic, charts (Chart.js), CRUD, admin panel, categories management
+- `js/chat.js` (~675 lines) — AI financial advisor floating chat widget
+- `js/i18n.js` (~1,180 lines) — English + Portuguese translations (600+ keys) and `t(key, replacements)` helper
 - `js/csrf.js`, `js/login.js`, `js/register.js`, `js/forgot-password.js` — page-specific modules
 
 ### API Structure
 
 Routes are organized in `server.js` by domain:
-- `/api/login`, `/api/register`, `/api/logout` — auth
+- `/api/login`, `/api/register`, `/api/logout`, `/api/forgot-password`, `/api/csrf-token` — auth
 - `/api/entries` — CRUD for income/expense entries
+- `/api/categories` — per-user category management (cap 100 per user)
 - `/api/user/*` — user settings (email, API keys, 2FA)
-- `/api/ai/*` — AI chat, PDF processing, model listing
+- `/api/ai/*`, `/api/process-pdf` — AI chat, PDF expense extraction, model listing
 - `/api/admin/*` — user management, couple linking, invite codes
-- `/api/paypal/*` — payment integration
+- `/api/paypal/*` — payment integration (invite-code purchases)
 
 ### AI Integration
 
-Three providers supported (Anthropic Claude, Google Gemini, OpenAI). Per-user encrypted API key storage with global env var fallback. AI features include PDF expense extraction and a financial advisor chat with server-side tools (summary, search, edit entries).
+Four credential types supported (per-user, encrypted, with global env var fallback):
+- **Anthropic** — `ANTHROPIC_API_KEY` or Claude Code OAuth token (`sk-ant-oat01-…`)
+- **Google Gemini** — `GEMINI_API_KEY`
+- **OpenAI** — `OPENAI_API_KEY`
+- **GitHub Copilot** — OAuth token (`gho_/ghu_/ghp_/github_pat_…`) routed through Copilot's OpenAI-compatible endpoint to access OpenAI/Anthropic/Google models on Copilot subscription credits
+
+AI features include PDF expense extraction (uses the user's category list) and a financial advisor chat with server-side tools (summary, search, edit entries) and optional Anthropic-native web search.
 
 ### Security Model
 
 - Passwords: bcryptjs (10 rounds)
-- Session: express-session with HTTP-only secure cookies
-- Field encryption: AES-256-CBC for emails, API keys, TOTP secrets
-- CSRF: per-session tokens validated on state-changing requests
-- Rate limiting: per-endpoint (login 5/15min, chat 30/15min, PDF 10/15min)
+- Sessions: `express-session` with `connect-pg-simple` Postgres store (since v2.6.6); HTTP-only secure cookies, 24h `maxAge`, expired rows pruned every 15 min
+- Field encryption: AES-256-CBC for emails, API keys, OAuth tokens, TOTP secrets
+- CSRF: per-session tokens validated on every non-GET/HEAD/OPTIONS `/api/*` request (except PayPal callbacks) — see `server.js` global middleware
+- Rate limiting: per-endpoint (login 5/15min, chat 30/15min, PDF 10/15min, plus register/forgot/totp/paypal/aiModels/general limiters)
 - SQL: all queries parameterized via `db/queries.js`
 - 2FA: TOTP with bcrypt-hashed backup codes
+- Static asset exposure narrowed to `/js` only (no `express.static(__dirname)`)
 
 ### iOS App
 
@@ -97,4 +106,8 @@ Capacitor 8 wraps the web app for iOS (`ios/` directory, app ID `com.assetmanage
 - Encryption/decryption helpers are defined in `server.js` (`encrypt()`/`decrypt()`)
 - The admin user is auto-created on startup from `ADMIN_USERNAME` + `ADMIN_PASSWORD_HASH` env vars
 - Rate limiters are defined per-endpoint at the top of `server.js`
-- Frontend uses a global `t(key)` function from `i18n.js` for all user-facing strings
+- Frontend uses a global `t(key, replacements)` function from `i18n.js` for all user-facing strings; falls back to returning the key when missing
+- **Per-user categories**: `user_categories` table; `getCategoriesForUserSelfHeal()` seeds the 17 `DEFAULT_CATEGORIES` slugs on first read; cap of 100/user enforced via `pg_advisory_xact_lock(userId)`; default labels are rendered via i18n keys `cat.<slug>` (not the DB label)
+- **Couple entries**: when both partners are linked, entries flagged `is_couple_expense` are visible to both; `ensurePartnerCategories()` auto-imports partner-category slugs into the active user's catalog
+- **Auth middleware** caches `req.user` for 5s in `userCache`; mutating user-related queries invalidate the cache
+- **Versioning**: `APP_VERSION` is read from `package.json` at boot — bumping `package.json` is the single source of truth for the release version


### PR DESCRIPTION
Documentation drift cleanup. Verified every claim against the live tree:

| Claim | Old | New | Source |
|---|---|---|---|
| server.js lines | ~3,400 | ~5,560 | `wc -l server.js` |
| queries.js lines | ~620 | ~1,270 | `wc -l db/queries.js` |
| app.js lines | ~3,000 | ~4,630 | `wc -l js/app.js` |
| i18n.js lines | ~45,000 (typo) | ~1,180 | `wc -l js/i18n.js` |
| index.html size | 83 KB | ~110 KB / ~2,840 lines | `ls -la` |
| API endpoints | 46 | ~60 | `grep -cE '^app\.(get\|post\|put\|delete\|patch)'` |
| Schema tables | 4 | 6 (added `user_categories`, `session`) | `grep CREATE TABLE db/schema.sql` |
| AI providers | 3 | 4 credential types (added GitHub Copilot OAuth, called out Claude Code OAuth as separate from API key) | `server.js:107,205,286` |
| Session store | express-session default | `connect-pg-simple` since v2.6.6 | PR #89 |
| Node version | 18.x+ | 18.18+ / 20.9+ / 22+ | `connect-pg-simple@10` engines |
| `hash-password` cmd | `npm run hash-password <pw>` | `npm run hash-password -- <pw>` | npm requires `--` to forward args |

Plus added new Key Patterns that previously weren't documented: per-user categories cap (100) with i18n labels, couple-entries partner sharing, `userCache` 5s invalidation pattern, `APP_VERSION` sourcing from package.json, narrowed `/js` static mount.

No code changes.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>