### PR TITLE
Fix three CodeQL alerts: ReDoS, biased RNG, log preview

### DIFF
--- a/db/queries.js
+++ b/db/queries.js
@@ -56,7 +56,13 @@ function parseJsonField(val) {
     try {
         return JSON.parse(val);
     } catch (err) {
-        console.error('Failed to parse JSON field:', err.message, '— value preview:', String(val).slice(0, 50));
+        // Don't log the value (issue #83 / CodeQL #6) — this helper runs on
+        // every encrypted credential column on user reads, and the previous
+        // 50-char preview leaked encryption-format metadata; if a regression
+        // ever stored plaintext in one of those columns, it would have
+        // leaked the credential too. Length + error message is enough to
+        // triage parse failures.
+        console.error('Failed to parse JSON field:', err.message, '— value length:', String(val).length);
         return null;
     }
 }

--- a/server.js
+++ b/server.js
@@ -1250,8 +1250,9 @@ app.post('/api/register', registerLimiter, asyncHandler(async (req, res) => {
 
     // Validate email format. Length + char check first so the regex never
     // sees an unbounded input (was a polynomial-ReDoS path: see issue #80
-    // / CodeQL #10). Regex itself uses non-overlapping bounded quantifiers
-    // for the same reason.
+    // / CodeQL #10). Regex itself uses bounded quantifiers as defense in
+    // depth — they overlap on `.` (the middle class still includes it),
+    // but bounding the repeats keeps any backtracking polynomial.
     if (email.length > 254 || /[<>]/.test(email)) {
         return res.status(400).json({ message: 'Invalid email format' });
     }

--- a/server.js
+++ b/server.js
@@ -683,11 +683,21 @@ const MAX_RESET_ATTEMPTS = 5;
 const RESET_ATTEMPT_WINDOW = 15 * 60 * 1000; // 15 minutes
 
 function generateResetCode() {
+    // Rejection sampling: 256 % 36 = 4, so bytes >= 252 (the unused tail)
+    // are discarded. This makes every alphabet character equiprobable
+    // (issue #81 / CodeQL #9 — the previous `byte % 36` left the first
+    // 4 alphabet chars ~14% more likely than the rest).
     const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
-    const bytes = crypto.randomBytes(8);
+    const max = 256 - (256 % alphabet.length);
     let code = '';
-    for (let i = 0; i < 8; i++) {
-        code += alphabet[bytes[i] % alphabet.length];
+    while (code.length < 8) {
+        const buf = crypto.randomBytes(8);
+        for (const b of buf) {
+            if (b < max) {
+                code += alphabet[b % alphabet.length];
+                if (code.length === 8) break;
+            }
+        }
     }
     return code;
 }
@@ -1238,12 +1248,15 @@ app.post('/api/register', registerLimiter, asyncHandler(async (req, res) => {
         return res.status(400).json({ message: 'All fields are required' });
     }
 
-    // Validate email format
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
+    // Validate email format. Length + char check first so the regex never
+    // sees an unbounded input (was a polynomial-ReDoS path: see issue #80
+    // / CodeQL #10). Regex itself uses non-overlapping bounded quantifiers
+    // for the same reason.
+    if (email.length > 254 || /[<>]/.test(email)) {
         return res.status(400).json({ message: 'Invalid email format' });
     }
-    if (email.length > 254 || /[<>]/.test(email)) {
+    const emailRegex = /^[^\s@]{1,64}@[^\s@]{1,255}\.[^\s@]{1,64}$/;
+    if (!emailRegex.test(email)) {
         return res.status(400).json({ message: 'Invalid email format' });
     }
 
@@ -2020,11 +2033,14 @@ app.put('/api/user/email', requireAuth, asyncHandler(async (req, res) => {
         return res.status(400).json({ message: 'Invalid email' });
     }
 
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(email)) {
+    // Length + char check first so the regex never sees an unbounded input
+    // (issue #80 / CodeQL #11). Regex uses bounded quantifiers as defense
+    // in depth.
+    if (email.length > 254 || /[<>]/.test(email)) {
         return res.status(400).json({ message: 'Invalid email format' });
     }
-    if (email.length > 254 || /[<>]/.test(email)) {
+    const emailRegex = /^[^\s@]{1,64}@[^\s@]{1,255}\.[^\s@]{1,64}$/;
+    if (!emailRegex.test(email)) {
         return res.status(400).json({ message: 'Invalid email format' });
     }
 


### PR DESCRIPTION
First of three stacked PRs targeting the redesign branch. Each addresses one of the open CodeQL security alerts.

## Summary
- **#80 ReDoS** — `/^[^\s@]+@[^\s@]+\.[^\s@]+$/` is run against unbounded request input in two places (register, email update). The two `[^\s@]+` groups overlap, so a non-matching input like `!@!.!.!.!.!.!.!.!` triggers polynomial backtracking. The 254-char length cap was checked **after** the regex. Fix: length + forbidden-char check now runs first, and the regex itself uses bounded quantifiers (`{1,64}@{1,255}.{1,64}`) as defense in depth.
- **#81 Biased RNG** — `generateResetCode()` did `byte % 36`. Since `256 = 7·36 + 4`, byte values 0–3 mapped to alphabet indices 0–3 with 8/256 probability while the rest got 7/256, making the first 4 chars ~14% more likely. Fix: rejection sampling (discard byte values ≥ 252).
- **#83 Log preview** — `parseJsonField()` runs on every encrypted credential column on user reads (`gemini_api_key`, `openai_api_key`, `anthropic_api_key`, `claude_oauth_token`, `github_copilot_token`). On parse failure it logged a 50-char preview of the raw value. Fix: log value length only, drop the preview.

## Test plan
- [ ] CodeQL re-run on the redesign branch resolves alerts #6, #9, #10, and #11
- [ ] Register a new user — email validation accepts normal addresses, rejects malformed/oversized ones with the same error message as before
- [ ] Settings → Email → Update / Remove email still works
- [ ] Forgot password → request a reset code → verify it's still 8 alphanumeric chars and accepted by the reset flow
- [ ] Existing reset code → 15-min expiry behaviour unchanged
- [ ] User reads (login + every page that pulls AI-credential flags) still log nothing of the encrypted blobs

## Stack
- **This PR (A)** — security fixes
- **PR B (next)** — Reports page (#92)
- **PR C** — Budgets page (#93)

🤖 Generated with [Claude Code](https://claude.com/claude-code)