### PR TITLE
Restore loading-state feedback on the v3.0.0 surfaces (#98)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1296,6 +1296,53 @@
             transition: opacity 0.15s, filter 0.15s;
         }
 
+        /* ── Hero row + KPI loading state (issue #98) ──
+           Dims the live numbers and overlays a shimmer block over the
+           bignum / each KPI value while data is loading. The same
+           `.is-loading` class also gets aria-busy via JS so screen-reader
+           users get the cue. */
+        .hero-networth.is-loading .bignum,
+        .hero-networth.is-loading .delta-row,
+        .hero-networth.is-loading .period {
+            opacity: 0.35;
+            filter: blur(2px);
+            transition: opacity 0.15s, filter 0.15s;
+        }
+        .kpi.is-loading .value,
+        .kpi.is-loading .delta-pill,
+        .kpi.is-loading .spark {
+            opacity: 0.35;
+            filter: blur(2px);
+            transition: opacity 0.15s, filter 0.15s;
+        }
+        .hero-networth.is-loading,
+        .kpi.is-loading {
+            position: relative;
+        }
+        .hero-networth.is-loading::after,
+        .kpi.is-loading::after {
+            content: '';
+            position: absolute;
+            left: 18px;
+            right: 18px;
+            top: 50%;
+            transform: translateY(-50%);
+            height: 14px;
+            background: linear-gradient(
+                90deg,
+                color-mix(in oklab, var(--line) 60%, var(--card)) 0%,
+                color-mix(in oklab, var(--primary-soft) 70%, var(--card)) 50%,
+                color-mix(in oklab, var(--line) 60%, var(--card)) 100%
+            );
+            background-size: 200% 100%;
+            border-radius: var(--radius-sm);
+            animation: skeletonShimmer 1.4s ease-in-out infinite;
+            pointer-events: none;
+        }
+        .hero-networth.is-loading::after {
+            height: 28px;
+        }
+
         table {
             width: 100%;
             border-collapse: collapse;

--- a/js/app.js
+++ b/js/app.js
@@ -904,6 +904,8 @@ function setChartsLoading(isLoading) {
     document.querySelectorAll('.chart-wrapper .chart-loading-overlay').forEach(el => {
         el.hidden = !isLoading;
     });
+    const section = document.querySelector('.charts-section');
+    if (section) section.setAttribute('aria-busy', String(!!isLoading));
 }
 
 function setEntriesLoading(isLoading) {
@@ -911,11 +913,27 @@ function setEntriesLoading(isLoading) {
     if (overlay) overlay.hidden = !isLoading;
     const summary = document.querySelector('.entries-section .summary');
     if (summary) summary.classList.toggle('is-loading', isLoading);
+    const section = document.querySelector('.entries-section');
+    if (section) section.setAttribute('aria-busy', String(!!isLoading));
+}
+
+// Toggles the `is-loading` class on the hero net-worth card + each KPI
+// tile, dimming live numbers and overlaying a shimmer block via CSS while
+// data is being fetched. Also flips aria-busy so screen-reader users get
+// the cue.
+function setHeroLoading(isLoading) {
+    const hero = document.getElementById('heroRow');
+    if (!hero) return;
+    hero.setAttribute('aria-busy', String(!!isLoading));
+    const networth = hero.querySelector('.hero-networth');
+    if (networth) networth.classList.toggle('is-loading', isLoading);
+    hero.querySelectorAll('.kpi').forEach(el => el.classList.toggle('is-loading', isLoading));
 }
 
 function setViewLoading(isLoading) {
     setChartsLoading(isLoading);
     setEntriesLoading(isLoading);
+    setHeroLoading(isLoading);
 }
 
 // ============ FILTER STATE ============
@@ -2541,8 +2559,7 @@ async function resolveBulkDuplicates(candidates) {
 
 confirmBulkEntriesBtn.addEventListener('click', async () => {
     if (bulkExtractedEntries.length > 0) {
-        const originalText = confirmBulkEntriesBtn.textContent;
-        confirmBulkEntriesBtn.disabled = true;
+        setButtonLoading(confirmBulkEntriesBtn, true);
         try {
             // Pre-flight duplicate detection — user confirms per duplicate.
             const candidates = bulkExtractedEntries.map(e => ({
@@ -2607,8 +2624,7 @@ confirmBulkEntriesBtn.addEventListener('click', async () => {
             console.error('Error saving bulk entries:', error);
             alert(t('bulk.errorSave', { message: error.message }));
         } finally {
-            confirmBulkEntriesBtn.disabled = false;
-            confirmBulkEntriesBtn.textContent = originalText;
+            setButtonLoading(confirmBulkEntriesBtn, false);
         }
     }
 });
@@ -3231,7 +3247,7 @@ document.addEventListener('DOMContentLoaded', () => {
             // Fetch + blob (rather than `<a href>` navigation) so we can
             // surface 4xx/5xx errors as in-modal alerts instead of having
             // the browser navigate away from the SPA to a JSON error body.
-            exportBtn.disabled = true;
+            setButtonLoading(exportBtn, true);
             try {
                 const res = await fetch('/api/reports/export?' + params.toString(), {
                     credentials: 'include'
@@ -3263,7 +3279,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 console.error('Report export failed:', e);
                 alert(t('report.exportError') || 'Export failed');
             } finally {
-                exportBtn.disabled = false;
+                setButtonLoading(exportBtn, false);
             }
         });
     }
@@ -3457,6 +3473,13 @@ document.addEventListener('DOMContentLoaded', () => {
                 // button. Avoids stranding a 0-amount row that the UI then
                 // renders as "no target set" with a disabled Clear.
                 const shouldDelete = isEmpty || v === 0;
+                // Visual feedback while the round-trip is in flight: disable
+                // the input + Clear button and mark the row aria-busy so SR
+                // users get the cue. The row gets re-rendered on success so
+                // these flags only matter on the brief in-flight window.
+                row.setAttribute('aria-busy', 'true');
+                input.disabled = true;
+                if (clearBtn) clearBtn.disabled = true;
                 try {
                     let res;
                     if (shouldDelete) {
@@ -3482,6 +3505,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 } catch (e) {
                     console.error('Budget save failed:', e);
                     alert(shouldDelete ? t('budget.deleteError') : t('budget.saveError'));
+                } finally {
+                    if (row.isConnected) {
+                        row.removeAttribute('aria-busy');
+                        input.disabled = false;
+                        if (clearBtn) clearBtn.disabled = clearBtn.disabled && !(input.value); // restore prior state
+                    }
                 }
             };
             input.addEventListener('blur', () => {
@@ -3492,6 +3521,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (e.key === 'Enter') { e.preventDefault(); input.blur(); }
             });
             clearBtn.addEventListener('click', async () => {
+                setButtonLoading(clearBtn, true);
                 try {
                     const res = await csrfFetch('/api/budgets/' + encodeURIComponent(slug), { method: 'DELETE' });
                     if (!res.ok && res.status !== 404) {
@@ -3503,6 +3533,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 } catch (e) {
                     console.error('DELETE /api/budgets failed:', e);
                     alert(t('budget.deleteError'));
+                } finally {
+                    // The row gets re-rendered on success, so this only
+                    // matters on the error path. Guard against the button
+                    // already being detached.
+                    if (clearBtn.isConnected) setButtonLoading(clearBtn, false);
                 }
             });
         });

--- a/js/app.js
+++ b/js/app.js
@@ -3475,8 +3475,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 const shouldDelete = isEmpty || v === 0;
                 // Visual feedback while the round-trip is in flight: disable
                 // the input + Clear button and mark the row aria-busy so SR
-                // users get the cue. The row gets re-rendered on success so
-                // these flags only matter on the brief in-flight window.
+                // users get the cue. The row gets re-rendered on success, so
+                // we only need to restore prior state on the error path —
+                // capture Clear's pre-request disabled state up-front so we
+                // can put it back exactly as `renderRow` left it.
+                const clearWasDisabled = clearBtn ? clearBtn.disabled : false;
                 row.setAttribute('aria-busy', 'true');
                 input.disabled = true;
                 if (clearBtn) clearBtn.disabled = true;
@@ -3509,7 +3512,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (row.isConnected) {
                         row.removeAttribute('aria-busy');
                         input.disabled = false;
-                        if (clearBtn) clearBtn.disabled = clearBtn.disabled && !(input.value); // restore prior state
+                        if (clearBtn) clearBtn.disabled = clearWasDisabled;
                     }
                 }
             };

--- a/js/app.js
+++ b/js/app.js
@@ -241,6 +241,11 @@ function setSingleChartLoading(chartName, isLoading) {
     if (!wrapper) return;
     const overlay = wrapper.querySelector('.chart-loading-overlay');
     if (overlay) overlay.hidden = !isLoading;
+    // aria-busy on the wrapper itself so screen readers get the cue too —
+    // this path skips `.charts-section` (which would imply ALL charts are
+    // loading), so the busy state lives on the specific wrapper.
+    if (isLoading) wrapper.setAttribute('aria-busy', 'true');
+    else wrapper.removeAttribute('aria-busy');
 }
 
 // Pending-rebuild timer ids. Rapid toggle clicks / theme swaps need to

--- a/js/app.js
+++ b/js/app.js
@@ -232,30 +232,56 @@ function buildCategoryChart(ctx, type, colors) {
     });
 }
 
+// Toggle the chart-loading overlay for a single chart by `data-chart` name.
+// Used for surface-specific loading flashes (the bar↔doughnut toggle and
+// theme rebuilds, where only some charts rebuild) without blanket-covering
+// every chart with `setChartsLoading`.
+function setSingleChartLoading(chartName, isLoading) {
+    const wrapper = document.querySelector(`.chart-wrapper[data-chart="${chartName}"]`);
+    if (!wrapper) return;
+    const overlay = wrapper.querySelector('.chart-loading-overlay');
+    if (overlay) overlay.hidden = !isLoading;
+}
+
 function setCategoryChartType(type) {
     if (!['bar', 'doughnut'].includes(type)) return;
     if (type === currentCategoryChartType) return;
     currentCategoryChartType = type;
-    if (categoryChart) categoryChart.destroy();
-    categoryChart = buildCategoryChart(_categoryCtxRef, type, _chartThemeRef);
-    // Re-populate with whatever the current filter view is showing
-    if (Array.isArray(currentFilteredEntries)) {
-        updateCharts(currentFilteredEntries, false, filterState.start, filterState.end);
-    }
+    // Show the loading skeleton on the category chart and defer the
+    // (synchronous) rebuild via setTimeout so the skeleton has a chance
+    // to paint first — otherwise the toggle feels instant-but-blank.
+    setSingleChartLoading('category', true);
+    setTimeout(() => {
+        if (categoryChart) categoryChart.destroy();
+        categoryChart = buildCategoryChart(_categoryCtxRef, type, _chartThemeRef);
+        // Re-populate with whatever the current filter view is showing
+        if (Array.isArray(currentFilteredEntries)) {
+            updateCharts(currentFilteredEntries, false, filterState.start, filterState.end);
+        }
+        setSingleChartLoading('category', false);
+    }, 0);
 }
 
 // Tear down and rebuild every chart so it picks up the freshly-resolved
 // CSS palette and font tokens — used after Appearance changes (theme /
 // typography). Safe to call before charts have been initialised.
 function reapplyChartTheme() {
-    [monthlyBalanceChart, incomeVsExpenseChart, categoryChart, categoryStackedChart].forEach(c => {
-        if (c) c.destroy();
-    });
-    monthlyBalanceChart = incomeVsExpenseChart = categoryChart = categoryStackedChart = null;
-    initializeCharts();
-    if (Array.isArray(currentFilteredEntries)) {
-        updateCharts(currentFilteredEntries, false, filterState.start, filterState.end);
-    }
+    // Flash the chart-loading skeletons across all four charts so the
+    // user gets feedback that the theme/typography swap took effect, then
+    // defer the rebuild past the current frame so the skeleton paints
+    // before the rebuild work blocks the main thread.
+    setChartsLoading(true);
+    setTimeout(() => {
+        [monthlyBalanceChart, incomeVsExpenseChart, categoryChart, categoryStackedChart].forEach(c => {
+            if (c) c.destroy();
+        });
+        monthlyBalanceChart = incomeVsExpenseChart = categoryChart = categoryStackedChart = null;
+        initializeCharts();
+        if (Array.isArray(currentFilteredEntries)) {
+            updateCharts(currentFilteredEntries, false, filterState.start, filterState.end);
+        }
+        setChartsLoading(false);
+    }, 0);
 }
 
 // Resolves the active --sans token to a concrete font-family string for

--- a/js/app.js
+++ b/js/app.js
@@ -232,10 +232,10 @@ function buildCategoryChart(ctx, type, colors) {
     });
 }
 
-// Toggle the chart-loading overlay for a single chart by `data-chart` name.
-// Used for surface-specific loading flashes (the bar↔doughnut toggle and
-// theme rebuilds, where only some charts rebuild) without blanket-covering
-// every chart with `setChartsLoading`.
+// Toggle the chart-loading overlay for a single chart by `data-chart`
+// name. Used for targeted loading flashes on an individual chart surface
+// (currently just the category chart's bar↔doughnut toggle) without
+// blanket-covering every chart with `setChartsLoading`.
 function setSingleChartLoading(chartName, isLoading) {
     const wrapper = document.querySelector(`.chart-wrapper[data-chart="${chartName}"]`);
     if (!wrapper) return;
@@ -243,15 +243,27 @@ function setSingleChartLoading(chartName, isLoading) {
     if (overlay) overlay.hidden = !isLoading;
 }
 
+// Pending-rebuild timer ids. Rapid toggle clicks / theme swaps need to
+// coalesce so we don't queue redundant rebuilds and don't toggle the
+// loading overlay off between queued runs (which would defeat the
+// "skeleton while rebuilding" intent).
+let _categoryRebuildTimer = null;
+let _themeRebuildTimer = null;
+
 function setCategoryChartType(type) {
     if (!['bar', 'doughnut'].includes(type)) return;
     if (type === currentCategoryChartType) return;
     currentCategoryChartType = type;
     // Show the loading skeleton on the category chart and defer the
     // (synchronous) rebuild via setTimeout so the skeleton has a chance
-    // to paint first — otherwise the toggle feels instant-but-blank.
+    // to paint first — otherwise the toggle feels instant-but-blank. If
+    // the user clicks again before the prior rebuild fires, cancel the
+    // pending one and schedule fresh; the skeleton stays on until the
+    // last-scheduled rebuild completes.
     setSingleChartLoading('category', true);
-    setTimeout(() => {
+    if (_categoryRebuildTimer) clearTimeout(_categoryRebuildTimer);
+    _categoryRebuildTimer = setTimeout(() => {
+        _categoryRebuildTimer = null;
         if (categoryChart) categoryChart.destroy();
         categoryChart = buildCategoryChart(_categoryCtxRef, type, _chartThemeRef);
         // Re-populate with whatever the current filter view is showing
@@ -264,14 +276,15 @@ function setCategoryChartType(type) {
 
 // Tear down and rebuild every chart so it picks up the freshly-resolved
 // CSS palette and font tokens — used after Appearance changes (theme /
-// typography). Safe to call before charts have been initialised.
+// typography). Safe to call before charts have been initialised. Same
+// coalescing as the category toggle: if the user changes theme twice in
+// quick succession, only the last call's rebuild actually runs and the
+// loading skeletons stay on until then.
 function reapplyChartTheme() {
-    // Flash the chart-loading skeletons across all four charts so the
-    // user gets feedback that the theme/typography swap took effect, then
-    // defer the rebuild past the current frame so the skeleton paints
-    // before the rebuild work blocks the main thread.
     setChartsLoading(true);
-    setTimeout(() => {
+    if (_themeRebuildTimer) clearTimeout(_themeRebuildTimer);
+    _themeRebuildTimer = setTimeout(() => {
+        _themeRebuildTimer = null;
         [monthlyBalanceChart, incomeVsExpenseChart, categoryChart, categoryStackedChart].forEach(c => {
             if (c) c.destroy();
         });

--- a/js/app.js
+++ b/js/app.js
@@ -2559,7 +2559,13 @@ async function resolveBulkDuplicates(candidates) {
 
 confirmBulkEntriesBtn.addEventListener('click', async () => {
     if (bulkExtractedEntries.length > 0) {
-        setButtonLoading(confirmBulkEntriesBtn, true);
+        // This button updates its own textContent mid-flight ("Saving 1/N",
+        // "Saving 2/N", …) — that progress text IS the loading feedback,
+        // so we deliberately don't add the .loading class here (it would
+        // hide the text via `color: transparent`). Just disabling and
+        // letting the per-iteration text update do the work.
+        const originalText = confirmBulkEntriesBtn.textContent;
+        confirmBulkEntriesBtn.disabled = true;
         try {
             // Pre-flight duplicate detection — user confirms per duplicate.
             const candidates = bulkExtractedEntries.map(e => ({
@@ -2624,7 +2630,8 @@ confirmBulkEntriesBtn.addEventListener('click', async () => {
             console.error('Error saving bulk entries:', error);
             alert(t('bulk.errorSave', { message: error.message }));
         } finally {
-            setButtonLoading(confirmBulkEntriesBtn, false);
+            confirmBulkEntriesBtn.disabled = false;
+            confirmBulkEntriesBtn.textContent = originalText;
         }
     }
 });

--- a/js/app.js
+++ b/js/app.js
@@ -3523,7 +3523,13 @@ document.addEventListener('DOMContentLoaded', () => {
                     }
                 }
             };
-            input.addEventListener('blur', () => {
+            input.addEventListener('focusout', (e) => {
+                // If focus is moving to this row's Clear button, the user
+                // is about to delete the budget — let the click handler
+                // run instead. If we save() here, it'd disable Clear before
+                // the click fires and the user would end up with an
+                // unintended PUT (and potentially miss the DELETE entirely).
+                if (e.relatedTarget === clearBtn) return;
                 const original = input.defaultValue;
                 if (input.value !== original) save();
             });


### PR DESCRIPTION
Closes #98.

Forward-only patch — keeps the v3.0.0 redesign exactly as-is, just re-attaches the loading affordances that regressed in the redesign.

## Summary
- **Hero net-worth + KPI cards**: new `.is-loading` CSS dims the live numbers (opacity + 2px blur, same idiom as `.summary.is-loading`) and overlays a shimmer block via ::after using the existing `skeletonShimmer` keyframes and palette tokens (so it looks right under Earthy / Dark / Light).
- **`setHeroLoading()` helper** added; `setViewLoading()` now calls it alongside `setChartsLoading()` / `setEntriesLoading()`. So initial dashboard load + every filter change shows skeletons across all four charts AND the hero/KPI tiles AND the entries table simultaneously.
- **`aria-busy`** flipped on `#heroRow` / `.charts-section` / `.entries-section` during loading so screen-reader users get the same cue. Budgets row gets `aria-busy` during its in-flight save.
- **Button spinners** wired to v3.0.0 modal action buttons via the existing `setButtonLoading()` helper:
  - **Reports modal Export** — full spinner.
  - **Budgets row Clear** — full spinner.
  - **Budgets row inline save** — input + Clear briefly disabled, row `aria-busy` (no spinner here, since the visual is the row refreshing on success).
  - **Bulk PDF Confirm** — kept the existing `disabled` + `textContent` pattern (the per-iteration "Saving 3/12" progress text IS the feedback for that flow; `.loading`'s `color: transparent` would have hidden it).
- **Synchronous chart rebuilds** — `setCategoryChartType` (bar↔doughnut) and `reapplyChartTheme` (Settings → Appearance theme/typography swaps) now flash the chart-loading skeleton via a `setTimeout(..., 0)`-deferred rebuild, so the user gets visible feedback that the action took effect. The category toggle uses a new `setSingleChartLoading('category', ...)` helper to scope the flash; theme swaps use `setChartsLoading()` since all four charts rebuild.

## Race-fix bonus
- Budgets row save uses `focusout` + `relatedTarget === clearBtn` guard, so clicking Clear when the input has unsaved changes runs DELETE cleanly instead of the input's blur firing `save()` first and disabling the Clear button before its click can land.

## What this is **not**
- Not a rollback of the redesign.
- Not a theme/palette change.
- No schema or API changes.
- Add / Edit / Delete / Bulk Process / chat send already had their own feedback (`setButtonLoading` or `chat-loading` dots) and are untouched.

## Test plan
- [ ] Initial dashboard load shows skeletons on all four charts + hero net-worth + KPI cards + entries table simultaneously, then resolves to real values.
- [ ] Quick-range / start-end / view-mode filter changes show a brief loading skeleton on the affected widgets.
- [ ] Reports Export (CSV and PDF) — button shows spinner during the request; re-enables on success/error.
- [ ] Budgets save (set a value and tab out) — input + Clear briefly disabled, row `aria-busy`, modal refreshes with new state.
- [ ] Budgets save then click Clear before tabbing out — DELETE runs (PUT does NOT race ahead of the click).
- [ ] Budgets clear — button shows spinner; row removed/refreshed.
- [ ] Bulk PDF Confirm — button shows "Saving 1/N → 2/N…" text progress while saving (no `.loading` spinner, intentional).
- [ ] Category chart toggle (bar ↔ doughnut) — skeleton flashes on that chart while it rebuilds.
- [ ] Settings → Appearance theme or typography swap — skeletons flash on all four charts while they rebuild.
- [ ] All loading indicators are visible against Earthy, Dark, and Light themes.
- [ ] Hero skeleton's shimmer animation runs at the same rate as the chart skeletons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)