### PR TITLE
perf: push report-export filters down to SQL

### DIFF
--- a/db/queries.js
+++ b/db/queries.js
@@ -417,6 +417,105 @@ async function getMyShareEntries(userId, partnerId, month) {
     });
 }
 
+/**
+ * Single-query report-export fetch (issue #97).
+ *
+ * Replaces the previous "fetch full history, then filter in Node" pattern
+ * used by /api/reports/export. Builds one parametrized SQL with WHERE
+ * clauses for view-mode-derived couple/individual scoping plus the user-
+ * supplied start/end/type/categories filters, so the DB returns only the
+ * rows the report needs. The existing per-view helpers
+ * (getEntriesByUser / getCoupleEntries / getMyShareEntries /
+ * getIndividualEntries) are left in place for non-export call sites such
+ * as the budgets / dashboard paths that still pass a single `month`.
+ *
+ * View-mode dispatch matches fetchEntriesForReport() in server.js:
+ *   combined + partner   → both users' couple-flagged entries
+ *   myshare  + partner   → own non-couple + both users' couple (halved JS-side)
+ *   myshare  no partner  → own non-couple only
+ *   individual + partner → own non-couple only
+ *   individual no partner / other → all user's entries
+ *
+ * Ordering matches the previous flow: SQL ORDER BY id then JS month
+ * stable-sort produced (month ASC, id ASC); we do that directly here.
+ *
+ * @param {number}   userId
+ * @param {number|null} partnerId
+ * @param {string}   viewMode  'individual' | 'combined' | 'myshare' | other
+ * @param {object}   filters
+ * @param {string|null} filters.start         YYYY-MM (inclusive) or null
+ * @param {string|null} filters.end           YYYY-MM (inclusive) or null
+ * @param {string|null} filters.typeFilter    'income' | 'expense' | 'all' / null
+ * @param {string[]|null} filters.categorySlugs  slugs to overlap on; null/[] = no filter
+ * @returns {Promise<object[]>} entries with same shape as the per-view helpers
+ */
+async function getEntriesForExport(userId, partnerId, viewMode, filters) {
+    const { start, end, typeFilter, categorySlugs } = filters || {};
+    const params = [];
+    const hasPartner = partnerId != null;
+    let baseWhere;
+
+    if (viewMode === 'combined' && hasPartner) {
+        params.push([userId, partnerId]);
+        baseWhere = `is_couple_expense = TRUE AND user_id = ANY($${params.length}::bigint[])`;
+    } else if (viewMode === 'myshare' && hasPartner) {
+        params.push(userId);
+        const pUser = params.length;
+        params.push(partnerId);
+        const pPartner = params.length;
+        baseWhere = `((user_id = $${pUser} AND is_couple_expense = FALSE)`
+            + ` OR (user_id = ANY(ARRAY[$${pUser}, $${pPartner}]::bigint[]) AND is_couple_expense = TRUE))`;
+    } else if (viewMode === 'myshare') {
+        // myshare without a partner collapses to own non-couple only (mirrors
+        // fetchEntriesForReport → getIndividualEntries).
+        params.push(userId);
+        baseWhere = `user_id = $${params.length} AND is_couple_expense = FALSE`;
+    } else if (viewMode === 'individual' && hasPartner) {
+        params.push(userId);
+        baseWhere = `user_id = $${params.length} AND is_couple_expense = FALSE`;
+    } else {
+        // individual without a partner (or any unknown viewMode) → all of the
+        // user's entries, including legacy couple-flagged rows from a former
+        // partnership. Mirrors the getEntriesByUser fallback in
+        // fetchEntriesForReport.
+        params.push(userId);
+        baseWhere = `user_id = $${params.length}`;
+    }
+
+    const conds = [baseWhere];
+    if (start) {
+        params.push(start);
+        conds.push(`month >= $${params.length}`);
+    }
+    if (end) {
+        params.push(end);
+        conds.push(`month <= $${params.length}`);
+    }
+    if (typeFilter && typeFilter !== 'all') {
+        params.push(typeFilter);
+        conds.push(`type = $${params.length}`);
+    }
+    if (Array.isArray(categorySlugs) && categorySlugs.length > 0) {
+        params.push(categorySlugs);
+        conds.push(`tags && $${params.length}::text[]`);
+    }
+
+    const sql = `SELECT * FROM entries WHERE ${conds.join(' AND ')} ORDER BY month ASC, id ASC`;
+    const { rows } = await pool.query(sql, params);
+
+    const halveCouple = viewMode === 'myshare' && hasPartner;
+    return rows.map(row => {
+        const entry = dbRowToEntry(row);
+        if (halveCouple && entry.isCoupleExpense) {
+            // Same half-away-from-zero rounding as getMyShareEntries so per-
+            // row display via .toFixed(2) and aggregate totals stay consistent.
+            const halved = entry.amount / 2;
+            entry.amount = Math.round((halved + Number.EPSILON) * 100) / 100;
+        }
+        return entry;
+    });
+}
+
 async function getEntryByIdAndUser(entryId, userId) {
     const { rows } = await pool.query(
         'SELECT * FROM entries WHERE id = $1 AND user_id = $2',
@@ -1298,6 +1397,7 @@ module.exports = {
     getPartnerCoupleEntries,
     getIndividualEntries,
     getMyShareEntries,
+    getEntriesForExport,
     getEntryByIdAndUser,
     findDuplicateEntry,
     findBulkDuplicateEntries,

--- a/db/queries.js
+++ b/db/queries.js
@@ -384,6 +384,18 @@ async function getIndividualEntries(userId, month) {
  * and `userId`, and `isCoupleExpense` is preserved so the UI can decorate
  * halved rows and disable edit/delete on them.
  */
+// Half-away-from-zero rounding used by both getMyShareEntries and
+// getEntriesForExport when splitting couple amounts. Keeps per-row
+// display via .toFixed(2) and aggregate totals consistent — the trade-
+// off being that summing many odd-cent couple entries can drift by up
+// to 1 cent per entry vs. the mathematical half, which we accept to
+// avoid sub-cent floats (e.g. 10.01 / 2 = 5.005 → "5.00" with IEEE-754
+// rounding).
+function halveCoupleAmount(amount) {
+    const halved = amount / 2;
+    return Math.round((halved + Number.EPSILON) * 100) / 100;
+}
+
 async function getMyShareEntries(userId, partnerId, month) {
     const params = month ? [userId, partnerId, month] : [userId, partnerId];
     const sql = month
@@ -403,15 +415,7 @@ async function getMyShareEntries(userId, partnerId, month) {
     return rows.map(row => {
         const entry = dbRowToEntry(row);
         if (entry.isCoupleExpense) {
-            // Round halved amounts to cents so per-row display (rendered via
-            // .toFixed(2)) and aggregate totals are always consistent. The
-            // trade-off is that summing many odd-cent couple entries can
-            // drift by up to 1 cent per entry vs. the mathematical half,
-            // which we accept as preferable to sub-cent floats that
-            // misrender in the UI (e.g. 10.01/2 = 5.005 -> "5.00" with
-            // IEEE-754 rounding). Use standard half-away-from-zero.
-            const halved = entry.amount / 2;
-            entry.amount = Math.round((halved + Number.EPSILON) * 100) / 100;
+            entry.amount = halveCoupleAmount(entry.amount);
         }
         return entry;
     });
@@ -507,10 +511,7 @@ async function getEntriesForExport(userId, partnerId, viewMode, filters) {
     return rows.map(row => {
         const entry = dbRowToEntry(row);
         if (halveCouple && entry.isCoupleExpense) {
-            // Same half-away-from-zero rounding as getMyShareEntries so per-
-            // row display via .toFixed(2) and aggregate totals stay consistent.
-            const halved = entry.amount / 2;
-            entry.amount = Math.round((halved + Number.EPSILON) * 100) / 100;
+            entry.amount = halveCoupleAmount(entry.amount);
         }
         return entry;
     });

--- a/server.js
+++ b/server.js
@@ -2477,9 +2477,11 @@ const VALID_REPORT_FORMATS = new Set(['csv', 'pdf']);
 const REPORT_TYPE_FILTERS = new Set(['all', 'income', 'expense']);
 
 // Mirrors GET /api/entries' filtering (viewMode + couple/individual rules)
-// but with month=null so we get the full history, then applies range/type/
-// category filters in-process. Pulled out so CSV and PDF paths share the
-// exact same dataset.
+// with a per-month scope. Used by the budgets endpoint, which only ever
+// needs a single month and benefits from the existing per-view helpers.
+// The /api/reports/export path uses fetchFilteredEntriesForReport below,
+// which pushes start/end/type/category filters into a single SQL query
+// (issue #97).
 async function fetchEntriesForReport(req, viewMode, month = null) {
     let validPartner = null;
     if (req.user.partnerId) {
@@ -2504,18 +2506,25 @@ async function fetchEntriesForReport(req, viewMode, month = null) {
     return db.getEntriesByUser(req.user.id, month);
 }
 
-function applyReportFilters(entries, { start, end, typeFilter, categorySet }) {
-    let out = entries;
-    if (start) out = out.filter(e => (e.month || '') >= start);
-    if (end)   out = out.filter(e => (e.month || '') <= end);
-    if (typeFilter && typeFilter !== 'all') {
-        out = out.filter(e => e.type === typeFilter);
+// Resolves the request's partner relationship and delegates to the single-
+// query export helper so range / type / category filters are applied in
+// SQL rather than in Node. Returned rows are already ordered by
+// (month ASC, id ASC), so writeCsvReport / writePdfReport can stream them
+// directly.
+async function fetchFilteredEntriesForReport(req, viewMode, filters) {
+    let validPartner = null;
+    if (req.user.partnerId) {
+        const partner = await db.findUserById(req.user.partnerId);
+        if (partner && partner.isActive && partner.partnerId === req.user.id) {
+            validPartner = partner;
+        }
     }
-    if (categorySet) {
-        out = out.filter(e => Array.isArray(e.tags) && e.tags.some(t => categorySet.has(t)));
-    }
-    out = out.slice().sort((a, b) => (a.month || '').localeCompare(b.month || ''));
-    return out;
+    return db.getEntriesForExport(
+        req.user.id,
+        validPartner ? validPartner.id : null,
+        viewMode,
+        filters
+    );
 }
 
 // CSV escaping with formula-injection mitigation: cells whose first
@@ -2730,7 +2739,7 @@ app.get('/api/reports/export', requireAuth, reportExportLimiter, asyncHandler(as
         return res.status(400).json({ message: 'Invalid type. Must be income, expense, or all.' });
     }
     const typeFilter = hasType ? String(rawType) : 'all';
-    let categorySet = null;
+    let categorySlugs = null;
     if (req.query.categories) {
         const slugs = String(req.query.categories).split(',').map(s => s.trim()).filter(Boolean);
         // Cap the category list at 50 to keep the URL/log surface bounded.
@@ -2741,11 +2750,12 @@ app.get('/api/reports/export', requireAuth, reportExportLimiter, asyncHandler(as
         if (!slugs.every(s => SLUG_REGEX.test(s))) {
             return res.status(400).json({ message: 'Invalid categories. Each slug must match the expected format.' });
         }
-        if (slugs.length) categorySet = new Set(slugs);
+        if (slugs.length) categorySlugs = slugs;
     }
 
-    const allEntries = await fetchEntriesForReport(req, viewMode);
-    const entries = applyReportFilters(allEntries, { start, end, typeFilter, categorySet });
+    const entries = await fetchFilteredEntriesForReport(req, viewMode, {
+        start, end, typeFilter, categorySlugs
+    });
 
     const dateStr = new Date().toISOString().slice(0, 10);
     const usernameSlug = String(req.user.username).replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 40) || 'user';
@@ -2777,7 +2787,7 @@ app.get('/api/reports/export', requireAuth, reportExportLimiter, asyncHandler(as
             start,
             end,
             typeFilter,
-            categories: categorySet ? [...categorySet] : null
+            categories: categorySlugs
         }
     });
 }));

--- a/server.js
+++ b/server.js
@@ -2476,6 +2476,21 @@ app.delete('/api/entries/:id', requireAuth, asyncHandler(async (req, res) => {
 const VALID_REPORT_FORMATS = new Set(['csv', 'pdf']);
 const REPORT_TYPE_FILTERS = new Set(['all', 'income', 'expense']);
 
+// Resolves req.user's partner relationship to a usable partner row, or
+// null. "Valid" means the partner exists, is active, AND the link is
+// mutual (partner.partnerId === req.user.id) so a one-sided link can't
+// leak entries between accounts. Several other server.js call sites
+// reproduce this exact 3-clause check — they could migrate to this
+// helper in a follow-up PR; for now scope stays within issue #97.
+async function resolveValidPartner(req) {
+    if (!req.user.partnerId) return null;
+    const partner = await db.findUserById(req.user.partnerId);
+    if (partner && partner.isActive && partner.partnerId === req.user.id) {
+        return partner;
+    }
+    return null;
+}
+
 // Mirrors GET /api/entries' filtering (viewMode + couple/individual rules)
 // with a per-month scope. Used by the budgets endpoint, which only ever
 // needs a single month and benefits from the existing per-view helpers.
@@ -2483,13 +2498,7 @@ const REPORT_TYPE_FILTERS = new Set(['all', 'income', 'expense']);
 // which pushes start/end/type/category filters into a single SQL query
 // (issue #97).
 async function fetchEntriesForReport(req, viewMode, month = null) {
-    let validPartner = null;
-    if (req.user.partnerId) {
-        const partner = await db.findUserById(req.user.partnerId);
-        if (partner && partner.isActive && partner.partnerId === req.user.id) {
-            validPartner = partner;
-        }
-    }
+    const validPartner = await resolveValidPartner(req);
     if (viewMode === 'combined' && validPartner) {
         return db.getCoupleEntries(req.user.id, validPartner.id, month);
     }
@@ -2512,13 +2521,7 @@ async function fetchEntriesForReport(req, viewMode, month = null) {
 // (month ASC, id ASC), so writeCsvReport / writePdfReport can stream them
 // directly.
 async function fetchFilteredEntriesForReport(req, viewMode, filters) {
-    let validPartner = null;
-    if (req.user.partnerId) {
-        const partner = await db.findUserById(req.user.partnerId);
-        if (partner && partner.isActive && partner.partnerId === req.user.id) {
-            validPartner = partner;
-        }
-    }
+    const validPartner = await resolveValidPartner(req);
     return db.getEntriesForExport(
         req.user.id,
         validPartner ? validPartner.id : null,


### PR DESCRIPTION
Closes #97.

## Summary

The Reports CSV / PDF export at `/api/reports/export` used to fetch the user's full history via the per-view DB helpers (with `month=null`) and apply `start` / `end` / `type` / `categories` filters in Node before writing the file. This PR moves those filters into one parametrized SQL query so only matching rows cross the wire.

## Changes

- **`db/queries.js`** — new `getEntriesForExport(userId, partnerId, viewMode, filters)`. One query dispatches on `viewMode` (matching the existing combined / myshare / individual / fallback rules from `fetchEntriesForReport`), pushes `month >= $start` / `month <= $end` / `type = $type` / `tags && $cats[]` into the `WHERE`, and orders by `(month ASC, id ASC)` so output ordering matches the previous "fetch + stable JS sort" pipeline. `myshare`'s couple-amount halving still happens in the JS `.map(...)` step, identical to `getMyShareEntries`.
- **`server.js`** — new `fetchFilteredEntriesForReport()` resolves the partner relationship and delegates to the new helper. `/api/reports/export` now calls it directly; `applyReportFilters()` is gone. The original `fetchEntriesForReport()` stays for the budgets path, which still queries by a single month.

## Verification

### EXPLAIN (local dev DB, ~300 rows)

| Query | Plan |
|---|---|
| individual + date range | **Bitmap Index Scan on `idx_entries_user_id_month`** + sort |
| individual + date + type | **Bitmap Index Scan on `idx_entries_user_id_month`** + residual filter |
| combined + date + categories | **Bitmap Index Scan on `idx_entries_user_id_month`** + residual filter (`is_couple_expense`, `tags &&`) |
| myshare OR query + date | Seq Scan |

The myshare OR clause falls back to Seq Scan on the dev DB because the table is too small for the planner to bother (~300 rows). Even with Seq Scan, the SQL pushdown is a win — only matching rows are returned to Node, instead of the user's full history. At production scale (thousands of rows) the planner should pick the index for the indexable predicates; if the OR query remains problematic, it can be rewritten as a `UNION ALL` later.

### Regression test (run locally, not committed)

Stable-canonicalized output of the **new** helper vs. the **old** "fetch full history + `applyReportFilters` in Node" pipeline, across:

- 3 users (one no-partner, two linked as a couple)
- 3 viewModes (`individual` / `combined` / `myshare`)
- 6 filter combos (no filters / date range / type / categories / all three / empty result)

= **54 / 54 cases byte-for-byte identical**.

## Test plan

- [x] `node --check db/queries.js server.js` passes.
- [x] Server boots and `/api/reports/export?format=csv` is reachable (401 without auth, as expected).
- [x] EXPLAIN confirms `idx_entries_user_id_month` is used for the indexable cases.
- [x] 54 / 54 regression cases match the previous pipeline output.
- [ ] **Live UI exercise** (not run by Claude): export a real CSV / PDF with a date range + category filter selected and confirm the output matches what was downloaded from `main` before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)