### PR TITLE
Ledger redesign: new visual identity, analytics rethink, shared theme tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,8 +59,9 @@ Copy `.env.example` to `.env`. Required variables:
 ### Frontend (no framework, no build)
 
 All frontend code is vanilla JavaScript loaded directly by the browser:
-- `index.html` (~140 KB / ~3,475 lines) — main dashboard with inline CSS, sidebar/topbar shell, hero KPI row with sparklines, Reports + Budgets modals
-- `js/app.js` (~5,640 lines) — dashboard logic, charts (Chart.js), CRUD, admin panel, categories, Reports/Budgets modals, theme + typography presets, mobile sidebar drawer with focus management, loading-state helpers (`setViewLoading` / `setHeroLoading` / `setChartsLoading` / `setEntriesLoading` / `setSingleChartLoading` / `setButtonLoading`)
+- `css/theme.css` — the single source of design tokens (Paper light / Graphite dark palettes, theme-invariant `--chrome-*` shell tokens, typography stacks, legacy `--color-*` aliases, `:focus-visible` + `prefers-reduced-motion` floor), linked by all four HTML pages before their inline component CSS
+- `index.html` (~3,400 lines) — main dashboard with inline component CSS, graphite sidebar/topbar shell, hero KPI row with sparklines, 3 chart panels + a budget status panel, Reports + Budgets modals
+- `js/app.js` (~5,600 lines) — dashboard logic, charts (Chart.js), CRUD, admin panel, categories, Reports/Budgets modals + dashboard budget panel (`refreshBudgetPanel`), theme + typography presets, mobile sidebar drawer with focus management + scroll lock, loading-state helpers (`setViewLoading` / `setHeroLoading` / `setChartsLoading` / `setEntriesLoading` / `setSingleChartLoading` / `setButtonLoading`)
 - `js/chat.js` (~800 lines) — AI financial advisor floating chat widget
 - `js/i18n.js` (~1,350 lines) — English + Portuguese translations (~700 keys) and `t(key, replacements)` helper
 - `js/csrf.js`, `js/login.js`, `js/register.js`, `js/forgot-password.js` — page-specific modules
@@ -107,7 +108,7 @@ AI features include PDF expense extraction (uses the user's category list) and a
 - Rate limiting: per-endpoint (login 5/15min, chat 30/15min, PDF 10/15min, plus register/forgot/totp/paypal/aiModels/general limiters)
 - SQL: all queries parameterized via `db/queries.js`
 - 2FA: TOTP with bcrypt-hashed backup codes
-- Static asset exposure narrowed to `/js` only (no `express.static(__dirname)`)
+- Static asset exposure narrowed to `/js` and `/css` only (no `express.static(__dirname)`)
 
 ## Key Patterns
 
@@ -121,6 +122,9 @@ AI features include PDF expense extraction (uses the user's category list) and a
 - **Couple entries**: when both partners are linked, entries flagged `is_couple_expense` are visible to both; `ensurePartnerCategories()` auto-imports partner-category slugs into the active user's catalog
 - **Auth middleware** caches `req.user` for 5s in `userCache`; mutating user-related queries invalidate the cache
 - **Localized currency in the UI**: hero / Budgets money formatting goes through `Intl.NumberFormat` keyed off `getLang()` — pt-BR → BRL/`R$`, en-US → USD/`$`. The KPI unit spans (`#kpiIncomeUnit` / `#kpiExpenseUnit`) are populated dynamically from the same locale.
-- **Theme + Typography presets** (v3.0): `<html data-theme="earthy|dark|light">` + `<html data-typography="editorial|modern|system">`, persisted in `localStorage` under `appTheme` / `appTypography`. An inline bootstrap script in every HTML entry point applies them before stylesheets resolve so there's no flash of default theme. Charts re-skin via `reapplyChartTheme()` which destroys + rebuilds with debouncing.
+- **Theme + Typography presets** ("Ledger" design system): Paper light is the default (no attribute); Graphite dark is `<html data-theme="dark">`. Typography is the Ledger stack (Bricolage Grotesque display / Geist body+numerals / JetBrains Mono labels) by default, or `<html data-typography="system">`. Persisted in `localStorage` under `appTheme` (`'paper' | 'dark'`; legacy `'light'` migrates to `'paper'`, no key follows `prefers-color-scheme`) / `appTypography` (`'system'` only; legacy `'modern'`/`'editorial'` are cleared). An inline bootstrap script in every HTML entry point applies them before stylesheets resolve so there's no flash of default theme. All tokens live in `css/theme.css`; the sidebar/topbar use theme-invariant `--chrome-*` tokens (graphite in both themes). Charts re-skin via `reapplyChartTheme()` which destroys + rebuilds with debouncing.
+- **Charts**: 3 Chart.js canvases (net-balance line, monthly cash-flow bars, categories) + an HTML budget status panel in the 4th grid slot. The categories chart has a 3-way toggle — `bar | doughnut | stacked` — persisted under `assetmgmt.categoryChartType`; `buildCategoryChart()` builds all three presentations and `updateCharts()` branches on the active mode. Money figures use `font-variant-numeric: tabular-nums`; entry tag chips are theme-neutral with a per-category color dot (`--tag-dot-color`).
+- **Dev note**: `server.js` pre-renders HTML into an in-memory cache at startup (`htmlCache`) — restart `npm start` after editing any HTML file to see the change.
+- **Hidden action bus**: the invisible `header.legacy-header` in index.html holds `#addEntryBtn`/`#settingsBtn`/`#logoutBtn`/`#adminPanelBtn`/`#openBulkUploadModal`, which app.js wires without null guards and the visible topbar/sidebar proxy clicks to. Do not delete it.
 - **Loading-state feedback**: `setViewLoading()` aggregates `setChartsLoading` + `setEntriesLoading` + `setHeroLoading`. Each helper toggles its CSS skeleton class AND `aria-busy` on the corresponding region. Async modal buttons go through `setButtonLoading(btn, isLoading)` (adds `.loading` class for the spinner pseudo-element + disabled). Sync chart rebuilds (`setCategoryChartType`, `reapplyChartTheme`) flash skeletons via `setTimeout(..., 0)`-deferred work with module-scope coalescing timers (`_categoryRebuildTimer` / `_themeRebuildTimer`).
 - **Versioning**: `APP_VERSION` is read from `package.json` at boot — bumping `package.json` is the single source of truth for the release version. Current line: 3.1.2.

--- a/css/theme.css
+++ b/css/theme.css
@@ -1,0 +1,129 @@
+/* ============================================================
+   Ledger design tokens — single source of truth for every page
+   (index.html, login.html, register.html, forgot-password.html).
+
+   Themes:
+     - Paper (light)   → default, no attribute
+     - Graphite (dark) → html[data-theme="dark"]
+   The sidebar/topbar chrome uses the theme-invariant --chrome-*
+   tokens and stays graphite in both themes.
+
+   Typography presets:
+     - Ledger (default) → Bricolage Grotesque / Geist / JetBrains Mono
+     - System           → html[data-typography="system"]
+
+   Pages load this via <link href="/css/theme.css"> BEFORE their
+   inline <style> block; component CSS stays per-page.
+   ============================================================ */
+
+:root {
+    /* Paper — porcelain light canvas */
+    --bg: #F6F6F4;
+    --bg-2: #EFEFEB;
+    --card: #FFFFFF;
+    --card-elevated: #FFFFFF;
+    --ink: #191C21;
+    --ink-2: #50555E;
+    --ink-3: #6E747F;
+    --line: #E3E3DE;
+    --line-2: #CFCFC8;
+    --primary: #0F6B4F;       /* evergreen */
+    --primary-soft: #D7EBE2;
+    --positive: #1B7A57;
+    --negative: #C2452D;
+    --warning: #B07A1F;
+    --info: #3B6E8F;
+    --chip: #ECECE7;
+    --ring: rgba(15, 107, 79, 0.25);
+
+    /* Chrome — sidebar/topbar shell, identical in both themes */
+    --chrome-bg: #15181D;
+    --chrome-ink: #E7E9EC;
+    --chrome-ink-dim: #9AA0AA;
+    --chrome-line: #262B33;
+    --chrome-active: rgba(61, 190, 139, 0.14);
+
+    /* Typography */
+    --display: "Bricolage Grotesque", ui-sans-serif, system-ui, sans-serif;
+    --sans: "Geist", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
+
+    /* Backwards-compatible aliases (legacy --serif / --color-* / --font-* /
+       --accent-* names still referenced by per-page component CSS and by
+       runtime reads in js/app.js) so the cascade keeps resolving without
+       touching every single rule. */
+    --serif: var(--display);
+    --font-display: var(--display);
+    --font-body: var(--sans);
+
+    --accent-1: var(--positive);
+    --accent-2: var(--warning);
+
+    --color-bg-deep: var(--bg-2);
+    --color-bg-base: var(--bg);
+    --color-bg-elevated: var(--card-elevated);
+    --color-bg-surface: var(--bg-2);
+
+    --color-accent-primary: var(--primary);
+    --color-accent-secondary: var(--warning);
+    --color-accent-tertiary: var(--positive);
+    --color-accent-danger: var(--negative);
+
+    --color-success: var(--positive);
+    --color-success-muted: color-mix(in oklab, var(--positive) 18%, var(--card));
+    --color-danger: var(--negative);
+    --color-danger-muted: color-mix(in oklab, var(--negative) 18%, var(--card));
+    --color-info: var(--info);
+
+    --color-text-primary: var(--ink);
+    --color-text-secondary: var(--ink-2);
+    --color-text-muted: var(--ink-3);
+
+    --color-border: var(--line);
+    --color-border-subtle: color-mix(in oklab, var(--line) 60%, var(--card));
+
+    --shadow-sm: 0 2px 8px rgba(25, 28, 33, 0.05);
+    --shadow-md: 0 8px 24px rgba(25, 28, 33, 0.07);
+    --shadow-lg: 0 16px 48px rgba(25, 28, 33, 0.11);
+    --shadow-glow: 0 0 40px var(--ring);
+
+    --radius-sm: 8px;
+    --radius-md: 10px;
+    --radius-lg: 14px;
+    --radius-xl: 18px;
+
+    --transition-fast: 0.15s ease;
+    --transition-base: 0.25s ease;
+    --transition-slow: 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* Graphite — dark canvas (chrome tokens unchanged on purpose) */
+html[data-theme="dark"] {
+    --bg: #131519;
+    --bg-2: #1B1E24;
+    --card: #1B1E24;
+    --card-elevated: #22262D;
+    --ink: #E9EAE6;
+    --ink-2: #A7ABB3;
+    --ink-3: #7D828C;
+    --line: #2A2E36;
+    --line-2: #3A3F49;
+    --primary: #3DBE8B;
+    --primary-soft: #133528;
+    --positive: #46C08A;
+    --negative: #E2674C;
+    --warning: #D9A94E;
+    --info: #6FA3C4;
+    --chip: #262A31;
+    --ring: rgba(61, 190, 139, 0.3);
+    --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.30);
+    --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.40);
+    --shadow-lg: 0 16px 48px rgba(0, 0, 0, 0.55);
+}
+
+/* Typography preset: System — no webfonts */
+html[data-typography="system"] {
+    --display: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    --mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+}

--- a/css/theme.css
+++ b/css/theme.css
@@ -36,11 +36,15 @@
     --chip: #ECECE7;
     --ring: rgba(15, 107, 79, 0.25);
 
-    /* Chrome — sidebar/topbar shell, identical in both themes */
+    /* Chrome — sidebar/topbar shell, identical in both themes.
+       --chrome-accent is the bright evergreen used for accents sitting ON
+       the dark chrome (active nav dot, primary chrome button); the theme's
+       own --primary would be too dark against it in the Paper theme. */
     --chrome-bg: #15181D;
     --chrome-ink: #E7E9EC;
     --chrome-ink-dim: #9AA0AA;
     --chrome-line: #262B33;
+    --chrome-accent: #3DBE8B;
     --chrome-active: rgba(61, 190, 139, 0.14);
 
     /* Typography */

--- a/css/theme.css
+++ b/css/theme.css
@@ -24,7 +24,7 @@
     --card-elevated: #FFFFFF;
     --ink: #191C21;
     --ink-2: #50555E;
-    --ink-3: #6E747F;
+    --ink-3: #61666F; /* AA (≥4.5:1) on --bg and --bg-2 at the 10–11px label sizes */
     --line: #E3E3DE;
     --line-2: #CFCFC8;
     --primary: #0F6B4F;       /* evergreen */
@@ -109,7 +109,7 @@ html[data-theme="dark"] {
     --card-elevated: #22262D;
     --ink: #E9EAE6;
     --ink-2: #A7ABB3;
-    --ink-3: #7D828C;
+    --ink-3: #878C96; /* AA (≥4.5:1) on --card at the 10–11px label sizes */
     --line: #2A2E36;
     --line-2: #3A3F49;
     --primary: #3DBE8B;
@@ -130,4 +130,28 @@ html[data-typography="system"] {
     --display: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
     --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
     --mono: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+/* ── Accessibility floor (shared by every page) ── */
+
+/* Visible keyboard focus on every interactive element. Inputs that draw
+   their own --ring box-shadow set outline: none on :focus and keep it;
+   everything else gets this. Elements sitting on the graphite chrome
+   should override outline-color to --chrome-accent (see index.html). */
+:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 2px;
+}
+
+/* Neutralize decorative motion (entrance fades, shimmer skeletons,
+   spinners, bouncing dots, hover transforms) for users who ask for it. */
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
 }

--- a/css/theme.css
+++ b/css/theme.css
@@ -28,6 +28,7 @@
     --line: #E3E3DE;
     --line-2: #CFCFC8;
     --primary: #0F6B4F;       /* evergreen */
+    --on-primary: #FFFFFF;    /* text/icons sitting on --primary or --positive fills */
     --primary-soft: #D7EBE2;
     --positive: #1B7A57;
     --negative: #C2452D;
@@ -113,6 +114,7 @@ html[data-theme="dark"] {
     --line: #2A2E36;
     --line-2: #3A3F49;
     --primary: #3DBE8B;
+    --on-primary: #0E2A1F;    /* dark ink — the bright primary needs dark text */
     --primary-soft: #133528;
     --positive: #46C08A;
     --negative: #E2674C;

--- a/forgot-password.html
+++ b/forgot-password.html
@@ -6,15 +6,21 @@
     <title>Reset Password - Asset Manager</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@300;400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400..700&family=Geist:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/theme.css">
     <script>
         // Apply persisted theme + typography before stylesheets resolve. Mirrors index.html.
         (function () {
             try {
                 var t = localStorage.getItem('appTheme');
+                if (t === 'light') { t = 'paper'; try { localStorage.setItem('appTheme', 'paper'); } catch (e) {} }
+                if (t !== 'paper' && t !== 'dark') {
+                    t = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'paper';
+                }
+                if (t === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
                 var f = localStorage.getItem('appTypography');
-                if (t === 'dark' || t === 'light') document.documentElement.setAttribute('data-theme', t);
-                if (f === 'modern' || f === 'system') document.documentElement.setAttribute('data-typography', f);
+                if (f === 'modern' || f === 'editorial') { f = null; try { localStorage.removeItem('appTypography'); } catch (e) {} }
+                if (f === 'system') document.documentElement.setAttribute('data-typography', 'system');
             } catch (e) {}
         })();
     </script>
@@ -59,90 +65,7 @@
             100% { transform: scale(1); opacity: 1; }
         }
 
-        :root {
-            /* Warm earthy palette — Clay & Sand */
-            --bg: #F3ECE0;
-            --bg-2: #EAE0CE;
-            --card: #FBF6EC;
-            --ink: #26201A;
-            --ink-2: #5A4E3F;
-            --ink-3: #8A7A65;
-            --line: #DDD0B8;
-            --primary: #B8593A;
-            --primary-soft: #E8BFAB;
-            --accent-1: #7A8450;
-            --accent-2: #C89A3E;
-            --positive: #6B8248;
-            --negative: #B8593A;
-
-            --serif: "Instrument Serif", "Iowan Old Style", Georgia, serif;
-            --sans: "Geist", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-            --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-
-            /* Backwards-compatible aliases */
-            --font-display: var(--serif);
-            --font-body: var(--sans);
-
-            --color-bg-deep: var(--bg-2);
-            --color-bg-base: var(--bg);
-            --color-bg-elevated: var(--card);
-            --color-bg-surface: var(--bg-2);
-
-            --color-accent-primary: var(--primary);
-            --color-accent-secondary: var(--accent-2);
-            --color-accent-tertiary: var(--accent-1);
-
-            --color-success: var(--positive);
-            --color-success-muted: color-mix(in oklab, var(--positive) 18%, var(--card));
-            --color-danger: var(--negative);
-            --color-danger-muted: color-mix(in oklab, var(--negative) 18%, var(--card));
-
-            --color-text-primary: var(--ink);
-            --color-text-secondary: var(--ink-2);
-            --color-text-muted: var(--ink-3);
-
-            --color-border: var(--line);
-
-            --shadow-lg: 0 16px 48px rgba(38, 32, 26, 0.12);
-
-            --radius-md: 10px;
-            --radius-lg: 14px;
-            --radius-xl: 18px;
-
-            --transition-fast: 0.15s ease;
-            --transition-base: 0.25s ease;
-        }
-
-        /* Theme + typography overrides — kept in sync with index.html */
-        html[data-theme="dark"] {
-            --bg: #1A1612; --bg-2: #221C16; --card: #2A231C;
-            --ink: #F0E6D6; --ink-2: #C9B99C; --ink-3: #8A7A65;
-            --line: #3A302A; --line-2: #4A3F36;
-            --primary: #D67A5C; --primary-soft: #5A2E20;
-            --accent-1: #9CA868; --accent-2: #D9B05A;
-            --positive: #8FA866; --negative: #D67A5C;
-            --chip: #3A302A; --ring: rgba(214, 122, 92, 0.28);
-            --shadow-lg: 0 16px 48px rgba(0, 0, 0, 0.55);
-        }
-        html[data-theme="light"] {
-            --bg: #FFFFFF; --bg-2: #F5F5F5; --card: #FAFAFA;
-            --ink: #1A1A1A; --ink-2: #4A4A4A; --ink-3: #888888;
-            --line: #E5E5E5; --line-2: #D0D0D0;
-            --primary: #2563EB; --primary-soft: #BFDBFE;
-            --accent-1: #059669; --accent-2: #D97706;
-            --positive: #059669; --negative: #DC2626;
-            --chip: #F0F0F0; --ring: rgba(37, 99, 235, 0.18);
-            --shadow-lg: 0 16px 48px rgba(0, 0, 0, 0.10);
-        }
-        html[data-typography="modern"] {
-            --serif: "Inter", ui-sans-serif, system-ui, sans-serif;
-            --sans: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-        }
-        html[data-typography="system"] {
-            --serif: ui-serif, Georgia, "Iowan Old Style", serif;
-            --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-            --mono: ui-monospace, SFMono-Regular, Menlo, monospace;
-        }
+        /* Design tokens live in /css/theme.css — shared by every page. */
 
         * {
             box-sizing: border-box;

--- a/forgot-password.html
+++ b/forgot-password.html
@@ -49,16 +49,6 @@
             100% { transform: rotate(360deg); }
         }
 
-        @keyframes float {
-            0%, 100% { transform: translateY(0) rotate(0deg); }
-            50% { transform: translateY(-20px) rotate(5deg); }
-        }
-
-        @keyframes pulse-glow {
-            0%, 100% { box-shadow: 0 0 60px color-mix(in oklab, var(--primary) 20%, transparent); }
-            50% { box-shadow: 0 0 100px color-mix(in oklab, var(--primary) 35%, transparent); }
-        }
-
         @keyframes checkmark {
             0% { transform: scale(0); opacity: 0; }
             50% { transform: scale(1.2); }
@@ -90,52 +80,19 @@
             overflow-y: auto;
         }
 
-        /* Noise texture overlay */
-        body::before {
-            content: '';
-            position: fixed;
-            inset: 0;
-            background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
-            opacity: 0.03;
-            pointer-events: none;
-            z-index: 1000;
-        }
-
-        /* Ambient background orbs */
+        /* Single ambient accent — a soft evergreen radial behind the card */
         .orb {
             position: fixed;
             border-radius: 50%;
-            filter: blur(80px);
+            filter: blur(90px);
             pointer-events: none;
             z-index: 0;
-        }
-
-        .orb-1 {
             width: 500px;
             height: 500px;
-            background: radial-gradient(circle, color-mix(in oklab, var(--primary) 15%, transparent) 0%, transparent 70%);
+            background: radial-gradient(circle, var(--primary-soft) 0%, transparent 70%);
             top: -150px;
             right: -100px;
-            animation: float 15s ease-in-out infinite;
-        }
-
-        .orb-2 {
-            width: 400px;
-            height: 400px;
-            background: radial-gradient(circle, rgba(59, 130, 246, 0.1) 0%, transparent 70%);
-            bottom: -100px;
-            left: -100px;
-            animation: float 18s ease-in-out infinite reverse;
-        }
-
-        .orb-3 {
-            width: 300px;
-            height: 300px;
-            background: radial-gradient(circle, rgba(168, 85, 247, 0.08) 0%, transparent 70%);
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
-            animation: float 12s ease-in-out infinite;
+            opacity: 0.55;
         }
 
         .container {
@@ -148,35 +105,36 @@
         }
 
         .app-title {
-            font-family: var(--font-display);
+            font-family: var(--display);
             font-size: 2.5rem;
             font-weight: 700;
-            color: var(--color-accent-primary);
+            color: var(--ink);
             text-align: center;
             margin-bottom: 2rem;
-            letter-spacing: -0.03em;
+            letter-spacing: -0.02em;
         }
 
         .reset-form {
-            background: var(--color-bg-elevated);
+            background: var(--card);
             padding: 3rem 2.5rem;
             border-radius: var(--radius-xl);
             box-shadow: var(--shadow-lg);
-            border: 1px solid var(--color-border);
+            border: 1px solid var(--line);
             text-align: center;
-            animation: fadeInUp 0.8s ease backwards, pulse-glow 4s ease-in-out infinite;
+            animation: fadeInUp 0.8s ease backwards;
             position: relative;
             overflow: hidden;
         }
 
+        /* Ledger tick — same motif as the dashboard section headings */
         .reset-form::before {
             content: '';
             position: absolute;
             top: 0;
-            left: 0;
-            right: 0;
-            height: 4px;
-            background: linear-gradient(90deg, var(--color-accent-primary) 0%, var(--color-accent-secondary) 50%, var(--color-accent-tertiary) 100%);
+            left: 2.5rem;
+            width: 24px;
+            height: 2px;
+            background: var(--primary);
         }
 
         .reset-form h2 {
@@ -248,27 +206,25 @@
         button {
             width: 100%;
             padding: 1.1rem;
-            background: linear-gradient(135deg, var(--color-accent-primary) 0%, var(--color-accent-tertiary) 100%);
-            color: var(--color-bg-deep);
+            background: var(--primary);
+            color: #fff;
             border: none;
             border-radius: var(--radius-md);
             font-size: 0.9rem;
-            font-family: var(--font-body);
-            font-weight: 700;
+            font-family: var(--sans);
+            font-weight: 600;
             cursor: pointer;
-            transition: all var(--transition-base);
+            transition: background var(--transition-base), box-shadow var(--transition-base), transform var(--transition-base);
             margin-top: 0.5rem;
-            text-transform: uppercase;
-            letter-spacing: 0.08em;
-            box-shadow: 0 4px 24px color-mix(in oklab, var(--primary) 30%, transparent);
+            letter-spacing: 0.02em;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
         }
 
         button:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 8px 32px color-mix(in oklab, var(--primary) 40%, transparent);
+            background: color-mix(in oklab, var(--primary) 88%, black);
+            box-shadow: 0 4px 16px var(--ring);
         }
 
         button:active {
@@ -279,7 +235,7 @@
             margin-top: 1.5rem;
             padding: 1rem 1.25rem;
             background: var(--color-danger-muted);
-            border: 1px solid rgba(239, 68, 68, 0.3);
+            border: 1px solid color-mix(in oklab, var(--negative) 35%, var(--card));
             border-radius: var(--radius-md);
             color: var(--color-danger);
             font-size: 0.875rem;
@@ -296,7 +252,7 @@
             margin-top: 1.5rem;
             padding: 1.25rem;
             background: var(--color-success-muted);
-            border: 1px solid rgba(16, 185, 129, 0.3);
+            border: 1px solid color-mix(in oklab, var(--positive) 35%, var(--card));
             border-radius: var(--radius-md);
             color: var(--color-success);
             font-size: 0.875rem;
@@ -335,10 +291,10 @@
         .info-message {
             margin-top: 1.5rem;
             padding: 1rem 1.25rem;
-            background: rgba(59, 130, 246, 0.1);
-            border: 1px solid rgba(59, 130, 246, 0.3);
+            background: color-mix(in oklab, var(--info) 10%, var(--card));
+            border: 1px solid color-mix(in oklab, var(--info) 30%, var(--card));
             border-radius: var(--radius-md);
-            color: #60a5fa;
+            color: var(--info);
             font-size: 0.875rem;
             display: none;
             text-align: left;
@@ -367,8 +323,8 @@
             left: 50%;
             margin-top: -10px;
             margin-left: -10px;
-            border: 2.5px solid rgba(255, 255, 255, 0.3);
-            border-top: 2.5px solid var(--color-text-primary);
+            border: 2.5px solid rgba(255, 255, 255, 0.35);
+            border-top: 2.5px solid #fff;
             border-radius: 50%;
             animation: spin 0.6s linear infinite;
         }
@@ -434,14 +390,10 @@
             .app-title {
                 font-size: 2rem;
             }
-
-            .orb-1, .orb-2 {
-                opacity: 0.5;
-            }
         }
         .lang-toggle {
             position: fixed;
-            bottom: 1.25rem;
+            bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
             right: 1.25rem;
             z-index: 999;
             width: 2.5rem;
@@ -471,9 +423,7 @@
 </head>
 <body>
     <button class="lang-toggle" data-i18n-title="lang.switch.title" onclick="setLang(getLang()==='en'?'pt':'en')" aria-label="Toggle language">🌐</button>
-    <div class="orb orb-1"></div>
-    <div class="orb orb-2"></div>
-    <div class="orb orb-3"></div>
+    <div class="orb" aria-hidden="true"></div>
 
     <div class="container">
         <h1 class="app-title" data-i18n="common.appName">Asset Manager</h1>

--- a/forgot-password.html
+++ b/forgot-password.html
@@ -209,7 +209,7 @@
             width: 100%;
             padding: 1.1rem;
             background: var(--primary);
-            color: #fff;
+            color: var(--on-primary);
             border: none;
             border-radius: var(--radius-md);
             font-size: 0.9rem;

--- a/forgot-password.html
+++ b/forgot-password.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Reset Password - Asset Manager</title>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='44' fill='%230F6B4F'/%3E%3Crect x='30' y='46' width='40' height='8' rx='2' fill='%23fff'/%3E%3C/svg%3E">
+    <meta name="theme-color" content="#F6F6F4">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400..700&family=Geist:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">

--- a/index.html
+++ b/index.html
@@ -113,8 +113,8 @@
             top: env(safe-area-inset-top, 0px);
             height: calc(100vh - env(safe-area-inset-top, 0px));
             overflow-y: auto;
-            background: var(--bg-2);
-            border-right: 1px solid var(--line);
+            background: var(--chrome-bg);
+            border-right: 1px solid var(--chrome-line);
             padding: 22px 16px 20px;
             display: flex;
             flex-direction: column;
@@ -129,29 +129,23 @@
         .brand-mark {
             width: 28px; height: 28px;
             border-radius: 50%;
-            background: var(--primary);
-            position: relative;
-            overflow: hidden;
+            background: var(--chrome-accent);
             flex: none;
         }
-        .brand-mark::after {
-            content: "";
-            position: absolute;
-            inset: 0;
-            background: radial-gradient(circle at 30% 30%, rgba(255,255,255,.35), transparent 60%);
-        }
         .brand-name {
-            font-family: var(--serif);
-            font-size: 22px;
+            font-family: var(--display);
+            font-weight: 600;
+            font-size: 19px;
+            letter-spacing: -0.01em;
             line-height: 1;
-            color: var(--ink);
+            color: var(--chrome-ink);
         }
         .brand-sub {
             font-family: var(--mono);
             font-size: 10px;
             letter-spacing: 0.08em;
             text-transform: uppercase;
-            color: var(--ink-3);
+            color: var(--chrome-ink-dim);
             margin-top: 4px;
         }
         .nav-section { display: flex; flex-direction: column; }
@@ -160,16 +154,16 @@
             font-size: 10px;
             letter-spacing: 0.1em;
             text-transform: uppercase;
-            color: var(--ink-3);
+            color: var(--chrome-ink-dim);
             padding: 12px 10px 6px;
         }
         .nav { display: flex; flex-direction: column; gap: 2px; }
         .nav-item {
             display: flex; align-items: center; gap: 10px;
             padding: 8px 10px;
-            border-radius: 8px;
+            border-radius: var(--radius-sm);
             font-size: 13.5px;
-            color: var(--ink-2);
+            color: var(--chrome-ink-dim);
             cursor: pointer;
             border: 1px solid transparent;
             user-select: none;
@@ -184,49 +178,48 @@
         .nav-item .dot {
             width: 6px; height: 6px;
             border-radius: 50%;
-            background: var(--line-2);
+            background: rgba(255, 255, 255, 0.18);
             flex: none;
         }
-        .nav-item:hover { background: rgba(0,0,0,.03); }
+        .nav-item:hover { background: rgba(255,255,255,.05); color: var(--chrome-ink); }
         .nav-item.active {
-            background: var(--card);
-            color: var(--ink);
-            border-color: var(--line);
-            box-shadow: 0 1px 0 rgba(0,0,0,.02);
+            background: var(--chrome-active);
+            color: var(--chrome-ink);
+            border-color: transparent;
         }
-        .nav-item.active .dot { background: var(--primary); }
+        .nav-item.active .dot { background: var(--chrome-accent); }
         .nav-item[aria-disabled="true"] { opacity: 0.55; cursor: default; }
         .nav-item[aria-disabled="true"]:hover { background: transparent; }
         .sidebar-foot {
             margin-top: auto;
-            border-top: 1px dashed var(--line-2);
+            border-top: 1px dashed var(--chrome-line);
             padding-top: 14px;
             display: flex; gap: 10px; align-items: center;
             font-size: 12px;
-            color: var(--ink-2);
+            color: var(--chrome-ink-dim);
         }
         .sidebar-foot .avatar {
             width: 30px; height: 30px; border-radius: 50%;
-            background: linear-gradient(135deg, var(--accent-2), var(--primary));
+            background: var(--chrome-accent);
             display: grid; place-items: center;
-            color: #fff; font-size: 11px;
+            color: var(--chrome-bg); font-size: 11px;
             font-family: var(--mono); font-weight: 600;
             flex: none;
         }
-        .sidebar-foot .who-name { font-size: 13px; color: var(--ink); }
+        .sidebar-foot .who-name { font-size: 13px; color: var(--chrome-ink); }
         .sidebar-foot .who-plan {
             font-family: var(--mono); font-size: 10px;
             letter-spacing: 0.06em; text-transform: uppercase;
-            color: var(--ink-3); margin-top: 2px;
+            color: var(--chrome-ink-dim); margin-top: 2px;
         }
 
         /* ---------- Topbar ---------- */
         .topbar {
             display: flex; align-items: center; justify-content: space-between;
-            padding: 18px 28px;
-            border-bottom: 1px solid var(--line);
+            padding: 16px 28px;
+            border-bottom: 1px solid var(--chrome-line);
             gap: 18px;
-            background: var(--bg);
+            background: var(--chrome-bg);
             position: sticky;
             top: env(safe-area-inset-top, 0px);
             z-index: 50;
@@ -235,16 +228,16 @@
             display: none; /* shown only on narrow screens via media query */
             width: 40px; height: 40px;
             padding: 0;
-            border: 1px solid var(--line);
+            border: 1px solid var(--chrome-line);
             border-radius: var(--radius-md);
-            background: var(--card);
-            color: var(--ink);
+            background: transparent;
+            color: var(--chrome-ink);
             cursor: pointer;
             align-items: center;
             justify-content: center;
             flex: none;
         }
-        .topbar-hamburger:hover { background: var(--bg-2); }
+        .topbar-hamburger:hover { background: rgba(255,255,255,.06); }
         .topbar-hamburger svg { width: 20px; height: 20px; display: block; }
         .sidebar-backdrop {
             display: none;
@@ -258,16 +251,38 @@
             font-family: var(--mono);
             font-size: 11px;
             letter-spacing: 0.06em;
-            color: var(--ink-3);
+            color: var(--chrome-ink-dim);
             text-transform: uppercase;
         }
         .topbar-greeting {
-            font-family: var(--serif);
-            font-size: 28px;
+            font-family: var(--display);
+            font-size: 22px;
             line-height: 1.1;
-            color: var(--ink);
+            letter-spacing: -0.01em;
+            color: var(--chrome-ink);
             margin: 0;
-            font-weight: 400;
+            font-weight: 600;
+        }
+        /* Chrome-aware buttons: actions sitting on the graphite topbar */
+        .topbar .btn,
+        .topbar button {
+            background: transparent;
+            border-color: var(--chrome-line);
+            color: var(--chrome-ink);
+        }
+        .topbar .btn:hover,
+        .topbar button:hover { background: rgba(255,255,255,.06); border-color: var(--chrome-line); }
+        .topbar .btn.primary,
+        .topbar .add-entry-btn {
+            background: var(--chrome-accent);
+            border-color: transparent;
+            color: var(--chrome-bg);
+            font-weight: 600;
+        }
+        .topbar .btn.primary:hover,
+        .topbar .add-entry-btn:hover {
+            background: color-mix(in oklab, var(--chrome-accent) 88%, white);
+            color: var(--chrome-bg);
         }
         .top-actions { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
         .view-toggle {
@@ -297,7 +312,6 @@
 
         /* ---------- Utility classes from prototype ---------- */
         .num { font-family: var(--mono); font-feature-settings: "tnum", "zero"; letter-spacing: -0.02em; }
-        .serif { font-family: var(--serif); font-weight: 400; letter-spacing: -0.015em; }
         .mono { font-family: var(--mono); }
         .tiny { font-size: 11px; }
         .muted { color: var(--ink-3); }
@@ -344,9 +358,10 @@
             min-height: 220px;
         }
         .hero-networth .bignum {
-            font-family: var(--serif);
-            font-weight: 400;
-            font-size: clamp(64px, 7vw, 110px);
+            font-family: var(--sans);
+            font-weight: 600;
+            font-variant-numeric: tabular-nums;
+            font-size: clamp(56px, 6.5vw, 96px);
             line-height: 0.95;
             letter-spacing: -0.03em;
             color: var(--ink);
@@ -398,8 +413,10 @@
             text-transform: uppercase;
         }
         .kpi .value {
-            font-family: var(--serif);
-            font-size: 38px;
+            font-family: var(--sans);
+            font-weight: 600;
+            font-variant-numeric: tabular-nums;
+            font-size: 32px;
             line-height: 1;
             color: var(--ink);
             letter-spacing: -0.02em;
@@ -651,12 +668,13 @@
             text-transform: uppercase;
         }
 
+        /* Ledger-rule tick: a short horizontal rule marks each section
+           heading, echoing the ruled lines of a paper ledger. */
         section h2::before {
             content: '';
-            width: 4px;
-            height: 14px;
+            width: 24px;
+            height: 2px;
             background: var(--primary);
-            border-radius: 2px;
         }
 
         .filters-section {
@@ -801,8 +819,8 @@
             border-color: var(--color-accent-primary);
         }
         .quick-range-btn.active {
-            background: linear-gradient(135deg, var(--color-accent-primary) 0%, var(--color-accent-tertiary) 100%);
-            color: var(--color-bg-deep);
+            background: var(--primary);
+            color: #fff;
             border-color: transparent;
         }
 
@@ -1466,13 +1484,13 @@
         }
 
         .modal-content h2 {
-            font-family: var(--serif);
-            font-size: 28px;
-            font-weight: 400;
+            font-family: var(--display);
+            font-size: 24px;
+            font-weight: 600;
             line-height: 1.1;
             margin: 0 0 22px 0;
             color: var(--ink);
-            letter-spacing: -0.015em;
+            letter-spacing: -0.01em;
         }
 
         .close {
@@ -1497,25 +1515,6 @@
         }
 
         @media (max-width: 768px) {
-            .header-buttons {
-                margin-left: 0;
-                width: 100%;
-                margin-top: 1rem;
-                justify-content: center;
-                flex-wrap: wrap;
-            }
-
-            .header-buttons button {
-                flex: 1 1 auto;
-                min-width: 0;
-                font-size: 0.7rem;
-                padding: 0.6rem 0.9rem;
-                white-space: normal;
-                text-align: center;
-                line-height: 1.3;
-                word-break: break-word;
-            }
-
             .view-mode-toggle {
                 flex-direction: column;
                 align-items: flex-start;
@@ -1560,37 +1559,9 @@
             section {
                 padding: 1.5rem;
             }
-
-            header {
-                padding: 1.25rem;
-            }
-
-            header h1 {
-                font-size: 1.35rem;
-            }
         }
 
         @media (max-width: 480px) {
-            header {
-                padding: 1rem;
-            }
-
-            .header-buttons {
-                width: 100%;
-                gap: 0.5rem;
-            }
-
-            .header-buttons button {
-                flex: 1;
-                min-width: 0;
-                padding: 0.6rem 0.5rem;
-                font-size: 0.65rem;
-                white-space: normal;
-                text-align: center;
-                letter-spacing: 0.02em;
-                line-height: 1.3;
-            }
-
             button {
                 white-space: normal;
                 text-align: center;
@@ -2005,16 +1976,18 @@
         }
         .couple-share-card:hover { border-color: var(--line-2); }
 
+        /* Ledger tick per person; the two partners get distinct hues
+           (evergreen vs petrol) that also color their progress bars. */
         .couple-share-card::before {
             content: '';
             position: absolute;
             top: 0;
-            left: 0;
-            right: 0;
+            left: 20px;
+            width: 24px;
             height: 2px;
         }
         .couple-share-card:first-child::before { background: var(--primary); }
-        .couple-share-card:last-child::before { background: var(--accent-1); }
+        .couple-share-card:last-child::before { background: var(--info); }
 
         .couple-share-card .person-name {
             font-family: var(--mono);
@@ -2027,10 +2000,11 @@
         }
 
         .couple-share-card .person-amount {
-            font-family: var(--serif);
-            font-size: 32px;
+            font-family: var(--sans);
+            font-variant-numeric: tabular-nums;
+            font-size: 30px;
             line-height: 1;
-            font-weight: 400;
+            font-weight: 600;
             color: var(--ink);
             letter-spacing: -0.02em;
             margin-bottom: 0.75rem;
@@ -2050,7 +2024,7 @@
             transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1);
         }
         .couple-share-card:last-child .person-bar {
-            background: var(--accent-1);
+            background: var(--info);
             height: 100%;
             border-radius: 9999px;
             transition: width 0.6s cubic-bezier(0.4, 0, 0.2, 1);
@@ -2077,8 +2051,8 @@
             content: '';
             position: absolute;
             top: 0;
-            left: 0;
-            right: 0;
+            left: 20px;
+            width: 24px;
             height: 2px;
             background: var(--positive);
         }
@@ -2092,11 +2066,12 @@
             margin-bottom: 0.5rem;
         }
         .couple-settlement .settlement-amount {
-            font-family: var(--serif);
-            font-size: 26px;
+            font-family: var(--sans);
+            font-variant-numeric: tabular-nums;
+            font-size: 24px;
             line-height: 1.1;
-            font-weight: 400;
-            letter-spacing: -0.015em;
+            font-weight: 600;
+            letter-spacing: -0.01em;
             color: var(--ink);
         }
         .couple-settlement .settlement-settled { color: var(--positive); }
@@ -2784,6 +2759,10 @@
         <div id="sidebarBackdrop" class="sidebar-backdrop" aria-hidden="true"></div>
 
     <div class="container">
+        <!-- Hidden action bus: app.js wires its handlers to these buttons
+             (addEntryBtn/openBulkUploadModal/settingsBtn/adminPanelBtn/
+             logoutBtn) and the visible topbar/sidebar controls proxy their
+             clicks here. Do not delete. -->
         <header class="legacy-header" hidden aria-hidden="true">
             <h1 data-i18n="common.assetManagement">Asset Management</h1>
             <div class="header-buttons">

--- a/index.html
+++ b/index.html
@@ -6,17 +6,27 @@
     <title>Asset Management Dashboard</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@300;400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400..700&family=Geist:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/theme.css">
     <script>
         // Apply persisted theme + typography before stylesheets resolve so
         // the page paints in the chosen palette (no flash of default theme).
+        // Themes: Paper (light, default) / Graphite (dark). No stored choice
+        // follows the OS preference; the legacy 'light' value migrates to
+        // 'paper' once. Legacy typography presets ('modern'/'editorial') are
+        // cleared — presets are now default (Ledger) or 'system'.
         // Mirrored on every HTML entry point — keep these blocks in sync.
         (function () {
             try {
                 var t = localStorage.getItem('appTheme');
+                if (t === 'light') { t = 'paper'; try { localStorage.setItem('appTheme', 'paper'); } catch (e) {} }
+                if (t !== 'paper' && t !== 'dark') {
+                    t = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'paper';
+                }
+                if (t === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
                 var f = localStorage.getItem('appTypography');
-                if (t === 'dark' || t === 'light') document.documentElement.setAttribute('data-theme', t);
-                if (f === 'modern' || f === 'system') document.documentElement.setAttribute('data-typography', f);
+                if (f === 'modern' || f === 'editorial') { f = null; try { localStorage.removeItem('appTypography'); } catch (e) {} }
+                if (f === 'system') document.documentElement.setAttribute('data-typography', 'system');
             } catch (e) { /* localStorage may be unavailable in private mode */ }
         })();
     </script>
@@ -39,132 +49,8 @@
             }
         }
 
-        :root {
-            /* Warm earthy palette — Clay & Sand */
-            --bg: #F3ECE0;
-            --bg-2: #EAE0CE;
-            --card: #FBF6EC;
-            --ink: #26201A;
-            --ink-2: #5A4E3F;
-            --ink-3: #8A7A65;
-            --line: #DDD0B8;
-            --line-2: #C9B99C;
-            --primary: #B8593A;       /* terracotta */
-            --primary-soft: #E8BFAB;
-            --accent-1: #7A8450;      /* olive */
-            --accent-2: #C89A3E;      /* ochre */
-            --positive: #6B8248;
-            --negative: #B8593A;
-            --chip: #E8DDC8;
-            --ring: rgba(184, 89, 58, 0.22);
-
-            /* Typography */
-            --serif: "Instrument Serif", "Iowan Old Style", Georgia, serif;
-            --sans: "Geist", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-            --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-
-            /* Backwards-compatible aliases (legacy --color-* / --font-* names
-               still referenced throughout this file) so the cascade keeps
-               resolving without touching every single rule. */
-            --font-display: var(--serif);
-            --font-body: var(--sans);
-
-            --color-bg-deep: var(--bg-2);
-            --color-bg-base: var(--bg);
-            --color-bg-elevated: var(--card);
-            --color-bg-surface: var(--bg-2);
-
-            --color-accent-primary: var(--primary);
-            --color-accent-secondary: var(--accent-2);
-            --color-accent-tertiary: var(--accent-1);
-            --color-accent-danger: var(--negative);
-
-            --color-success: var(--positive);
-            --color-success-muted: color-mix(in oklab, var(--positive) 18%, var(--card));
-            --color-danger: var(--negative);
-            --color-danger-muted: color-mix(in oklab, var(--negative) 18%, var(--card));
-            --color-info: #3F6E8C;
-
-            --color-text-primary: var(--ink);
-            --color-text-secondary: var(--ink-2);
-            --color-text-muted: var(--ink-3);
-
-            --color-border: var(--line);
-            --color-border-subtle: color-mix(in oklab, var(--line) 60%, var(--card));
-
-            --shadow-sm: 0 2px 8px rgba(38, 32, 26, 0.06);
-            --shadow-md: 0 8px 24px rgba(38, 32, 26, 0.08);
-            --shadow-lg: 0 16px 48px rgba(38, 32, 26, 0.12);
-            --shadow-glow: 0 0 40px var(--ring);
-
-            --radius-sm: 8px;
-            --radius-md: 10px;
-            --radius-lg: 14px;
-            --radius-xl: 18px;
-
-            --transition-fast: 0.15s ease;
-            --transition-base: 0.25s ease;
-            --transition-slow: 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-        }
-
-        /* Dark — warm dark with terracotta accents */
-        html[data-theme="dark"] {
-            --bg: #1A1612;
-            --bg-2: #221C16;
-            --card: #2A231C;
-            --ink: #F0E6D6;
-            --ink-2: #C9B99C;
-            --ink-3: #8A7A65;
-            --line: #3A302A;
-            --line-2: #4A3F36;
-            --primary: #D67A5C;
-            --primary-soft: #5A2E20;
-            --accent-1: #9CA868;
-            --accent-2: #D9B05A;
-            --positive: #8FA866;
-            --negative: #D67A5C;
-            --chip: #3A302A;
-            --ring: rgba(214, 122, 92, 0.28);
-            --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.30);
-            --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.40);
-            --shadow-lg: 0 16px 48px rgba(0, 0, 0, 0.55);
-        }
-
-        /* Light — clean modern light with cool blue accent */
-        html[data-theme="light"] {
-            --bg: #FFFFFF;
-            --bg-2: #F5F5F5;
-            --card: #FAFAFA;
-            --ink: #1A1A1A;
-            --ink-2: #4A4A4A;
-            --ink-3: #888888;
-            --line: #E5E5E5;
-            --line-2: #D0D0D0;
-            --primary: #2563EB;
-            --primary-soft: #BFDBFE;
-            --accent-1: #059669;
-            --accent-2: #D97706;
-            --positive: #059669;
-            --negative: #DC2626;
-            --chip: #F0F0F0;
-            --ring: rgba(37, 99, 235, 0.18);
-            --shadow-sm: 0 2px 8px rgba(0, 0, 0, 0.05);
-            --shadow-md: 0 8px 24px rgba(0, 0, 0, 0.07);
-            --shadow-lg: 0 16px 48px rgba(0, 0, 0, 0.10);
-        }
-
-        /* Typography presets — override font stacks; loaded fonts come from
-           the Google Fonts URL above (Editorial uses Instrument+Geist;
-           Modern uses Inter; System uses no Google Fonts). */
-        html[data-typography="modern"] {
-            --serif: "Inter", ui-sans-serif, system-ui, sans-serif;
-            --sans: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-        }
-        html[data-typography="system"] {
-            --serif: ui-serif, Georgia, "Iowan Old Style", serif;
-            --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-            --mono: ui-monospace, SFMono-Regular, Menlo, monospace;
-        }
+        /* Design tokens (palettes, chrome, typography presets, radii,
+           shadows) live in /css/theme.css — shared by every page. */
 
         * {
             box-sizing: border-box;

--- a/index.html
+++ b/index.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Asset Management Dashboard</title>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='44' fill='%230F6B4F'/%3E%3Crect x='30' y='46' width='40' height='8' rx='2' fill='%23fff'/%3E%3C/svg%3E">
+    <meta name="theme-color" content="#15181D">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400..700&family=Geist:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
@@ -51,6 +53,27 @@
 
         /* Design tokens (palettes, chrome, typography presets, radii,
            shadows) live in /css/theme.css — shared by every page. */
+
+        /* Skip link: visually hidden until focused via keyboard */
+        .skip-link {
+            position: absolute;
+            left: -9999px;
+            top: 0;
+            z-index: 300;
+            background: var(--primary);
+            color: #fff;
+            padding: 10px 16px;
+            border-radius: 0 0 var(--radius-md) 0;
+            font-size: 13px;
+            font-weight: 600;
+            text-decoration: none;
+        }
+        .skip-link:focus { left: 0; }
+
+        /* On the graphite chrome the theme --primary can be too dark for a
+           visible focus ring — use the bright chrome accent there. */
+        .sidebar :focus-visible,
+        .topbar :focus-visible { outline-color: var(--chrome-accent); }
 
         * {
             box-sizing: border-box;
@@ -456,6 +479,9 @@
             }
             .sidebar.open { transform: translateX(0); }
             .topbar-hamburger { display: inline-flex; }
+            /* Lock the page scroll while the drawer is open (class toggled
+               by openSidebar/closeSidebar in app.js). */
+            body.drawer-open { overflow: hidden; }
         }
         @media (max-width: 640px) {
             .hero-kpis { grid-template-columns: 1fr; }
@@ -2703,6 +2729,7 @@
     </style>
 </head>
 <body>
+    <a class="skip-link" href="#mainContent" data-i18n="a11y.skipToContent">Skip to content</a>
     <button class="lang-toggle" data-i18n-title="lang.switch.title" onclick="setLang(getLang()==='en'?'pt':'en')" aria-label="Toggle language">🌐</button>
 
     <!-- AI Chat Widget -->
@@ -2798,7 +2825,7 @@
                 <button type="button" id="topbarAddEntryBtn" class="btn primary" data-i18n-title="dash.addEntry" title="Add New Entry"><span aria-hidden="true">+</span> <span data-i18n="dash.addEntry">Add New Entry</span></button>
             </div>
         </div>
-        <main>
+        <main id="mainContent" tabindex="-1">
             <!-- Add Entry Modal -->
             <div id="entryModal" class="modal">
                 <div class="modal-content">

--- a/index.html
+++ b/index.html
@@ -3191,6 +3191,7 @@
                             </div>
                             <div id="categoryChips" class="category-chips" role="group" data-i18n-aria-label="dash.category" aria-label="Categories"></div>
                         </div>
+                        <button id="selectAllCategories" class="filter-btn" data-i18n="filter.selectAllCats">All Categories</button>
                         <button id="clearFilters" class="filter-btn" data-i18n="dash.clearFilters">Clear Filters</button>
                     </div>
                     <div id="activeFiltersBar" class="active-filters-bar" hidden>
@@ -3279,6 +3280,9 @@
                         <div class="chart-loading-overlay" hidden><div class="chart-skeleton"></div></div>
                     </div>
                     <div class="chart-wrapper" data-chart="incomeVsExpense">
+                        <div class="chart-type-toggle" role="group" data-i18n-aria-label="chart.avgToggleHelp" aria-label="Average lines">
+                            <button type="button" class="chart-type-btn active" id="avgLinesToggle" aria-pressed="true" data-i18n="chart.avgToggle" data-i18n-title="chart.avgToggleHelp" title="Show or hide the average lines">Avg</button>
+                        </div>
                         <canvas id="incomeVsExpenseChart"></canvas>
                         <div class="chart-empty-state" hidden data-i18n="chart.noData">No data for current filters</div>
                         <div class="chart-loading-overlay" hidden><div class="chart-skeleton"></div></div>

--- a/index.html
+++ b/index.html
@@ -1056,60 +1056,88 @@
             display: block;
         }
 
-        .summary {
-            display: grid;
-            grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-            gap: 18px;
-            margin-bottom: 22px;
+        /* ── Budget status panel (4th slot of the charts grid) ── */
+        .budget-panel {
+            display: flex;
+            flex-direction: column;
         }
-
-        .summary-item {
-            background: var(--card);
-            padding: 22px;
-            border-radius: var(--radius-lg);
-            border: 1px solid var(--line);
-            position: relative;
+        .budget-panel-head {
+            display: flex;
+            align-items: baseline;
+            justify-content: space-between;
+            gap: 8px;
+            margin-bottom: 14px;
+        }
+        .budget-panel-head h3 {
+            margin: 0;
+            font-family: var(--display);
+            font-size: 14px;
+            font-weight: 600;
+            color: var(--ink);
+        }
+        .budget-panel-body {
+            flex: 1;
+            min-height: 0;
+            overflow-y: auto;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+        .budget-row { display: flex; flex-direction: column; gap: 5px; }
+        .budget-row--overall {
+            padding-bottom: 12px;
+            border-bottom: 1px dashed var(--line);
+        }
+        .budget-row-top {
+            display: flex;
+            justify-content: space-between;
+            align-items: baseline;
+            gap: 8px;
+        }
+        .budget-row-name {
+            font-size: 12.5px;
+            color: var(--ink-2);
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            min-width: 0;
             overflow: hidden;
-            transition: border-color var(--transition-base);
+            text-overflow: ellipsis;
+            white-space: nowrap;
         }
-
-        .summary-item:hover {
-            border-color: var(--line-2);
+        .budget-row-name .budget-dot {
+            width: 7px; height: 7px;
+            border-radius: 2px;
+            background: var(--budget-dot-color, var(--ink-3));
+            flex: none;
         }
-
-        .summary-item::before {
-            content: '';
-            position: absolute;
-            top: 0;
-            left: 0;
-            right: 0;
-            height: 2px;
-            background: var(--primary);
-            opacity: 0;
-            transition: opacity var(--transition-base);
-        }
-
-        .summary-item:hover::before { opacity: 1; }
-
-        .summary-item span:first-child {
-            display: block;
+        .budget-row-nums {
             font-family: var(--mono);
             font-size: 11px;
-            color: var(--ink-2);
-            font-weight: 500;
-            margin-bottom: 10px;
-            text-transform: uppercase;
-            letter-spacing: 0.08em;
+            font-feature-settings: "tnum";
+            color: var(--ink-3);
+            white-space: nowrap;
         }
-
-        .summary-item span:last-child {
-            display: block;
-            font-family: var(--serif);
-            font-size: 38px;
-            line-height: 1;
-            font-weight: 400;
-            color: var(--ink);
-            letter-spacing: -0.02em;
+        .budget-row-track {
+            height: 6px;
+            border-radius: 9999px;
+            background: var(--bg-2);
+            overflow: hidden;
+        }
+        .budget-row-fill {
+            height: 100%;
+            border-radius: 9999px;
+            transition: width 0.4s ease;
+        }
+        .budget-panel-empty {
+            font-size: 12.5px;
+            color: var(--ink-3);
+            margin: auto 0;
+            text-align: center;
+        }
+        .budget-panel-manage {
+            margin-top: 14px;
+            align-self: flex-start;
         }
 
         .entries-table {
@@ -1194,12 +1222,6 @@
             0%, 100% { opacity: 0.3; transform: scale(0.85); }
             50%      { opacity: 1;   transform: scale(1.15); }
         }
-        .summary.is-loading .summary-item span:last-child {
-            opacity: 0.35;
-            filter: blur(2px);
-            transition: opacity 0.15s, filter 0.15s;
-        }
-
         /* ── Hero row + KPI loading state (issue #98) ──
            Dims the live numbers and overlays a shimmer block over the
            bignum / each KPI value while data is loading. The same
@@ -1370,9 +1392,13 @@
             animation: spin 0.6s linear infinite;
         }
 
-        /* Tag badge styles */
+        /* Tag badge styles — theme-neutral chip with a per-category color dot
+           (the dot color is the user's stored category color, set inline by
+           displayEntries via --tag-dot-color). */
         .tag {
-            display: inline-block;
+            display: inline-flex;
+            align-items: center;
+            gap: 5px;
             padding: 0.25rem 0.6rem;
             border-radius: 9999px;
             font-size: 0.65rem;
@@ -1380,26 +1406,17 @@
             margin: 0.1rem;
             text-transform: uppercase;
             letter-spacing: 0.05em;
-            border: 1px solid transparent;
+            background: var(--chip);
+            color: var(--ink-2);
+            border: 1px solid var(--line);
         }
-
-        .tag-food { background: rgba(251, 191, 36, 0.15); color: #fbbf24; border-color: rgba(251, 191, 36, 0.3); }
-        .tag-groceries { background: rgba(34, 197, 94, 0.15); color: #22c55e; border-color: rgba(34, 197, 94, 0.3); }
-        .tag-transport { background: rgba(59, 130, 246, 0.15); color: #3b82f6; border-color: rgba(59, 130, 246, 0.3); }
-        .tag-travel { background: rgba(6, 182, 212, 0.15); color: #06b6d4; border-color: rgba(6, 182, 212, 0.3); }
-        .tag-entertainment { background: rgba(168, 85, 247, 0.15); color: #a855f7; border-color: rgba(168, 85, 247, 0.3); }
-        .tag-utilities { background: rgba(99, 102, 241, 0.15); color: #6366f1; border-color: rgba(99, 102, 241, 0.3); }
-        .tag-healthcare { background: rgba(236, 72, 153, 0.15); color: #ec4899; border-color: rgba(236, 72, 153, 0.3); }
-        .tag-education { background: rgba(20, 184, 166, 0.15); color: #14b8a6; border-color: rgba(20, 184, 166, 0.3); }
-        .tag-shopping { background: rgba(249, 115, 22, 0.15); color: #f97316; border-color: rgba(249, 115, 22, 0.3); }
-        .tag-subscription { background: rgba(132, 204, 22, 0.15); color: #84cc16; border-color: rgba(132, 204, 22, 0.3); }
-        .tag-housing { background: rgba(148, 163, 184, 0.15); color: #94a3b8; border-color: rgba(148, 163, 184, 0.3); }
-        .tag-salary { background: rgba(16, 185, 129, 0.15); color: #10b981; border-color: rgba(16, 185, 129, 0.3); }
-        .tag-freelance { background: rgba(45, 212, 191, 0.15); color: #2dd4bf; border-color: rgba(45, 212, 191, 0.3); }
-        .tag-investment { background: rgba(139, 92, 246, 0.15); color: #8b5cf6; border-color: rgba(139, 92, 246, 0.3); }
-        .tag-transfer { background: rgba(14, 165, 233, 0.15); color: #0ea5e9; border-color: rgba(14, 165, 233, 0.3); }
-        .tag-wedding { background: rgba(244, 114, 182, 0.15); color: #f472b6; border-color: rgba(244, 114, 182, 0.3); }
-        .tag-other { background: rgba(100, 116, 139, 0.15); color: #64748b; border-color: rgba(100, 116, 139, 0.3); }
+        .tag::before {
+            content: "";
+            width: 7px; height: 7px;
+            border-radius: 2px;
+            background: var(--tag-dot-color, var(--ink-3));
+            flex: none;
+        }
 
         /* Preview table selects */
         .preview-select {
@@ -1540,15 +1557,7 @@
                 height: 340px;
             }
 
-            .chart-wrapper[data-chart="categoryStacked"] {
-                height: 400px;
-            }
-
             .charts-container {
-                grid-template-columns: 1fr;
-            }
-
-            .summary {
                 grid-template-columns: 1fr;
             }
 
@@ -1603,7 +1612,6 @@
             .hero-networth { padding: 18px; min-height: 0; }
             .hero-networth .bignum { font-size: clamp(40px, 11vw, 64px); }
             .chart-wrapper { height: 280px; padding: 12px; }
-            .chart-wrapper[data-chart="categoryStacked"] { height: 320px; }
             .charts-container { gap: 1rem; }
         }
 
@@ -3151,26 +3159,6 @@
                                 <button type="button" id="manageCategoriesBtn" class="link-btn" data-i18n="category.manage">Manage</button>
                             </div>
                             <div id="categoryChips" class="category-chips" role="group" data-i18n-aria-label="dash.category" aria-label="Categories"></div>
-                            <!-- Hidden native select kept for backwards-compat / testing; populated from chips -->
-                            <select id="categoryFilter" multiple hidden aria-hidden="true" tabindex="-1">
-                                <option value="food">Food</option>
-                                <option value="groceries">Groceries</option>
-                                <option value="transport">Transport</option>
-                                <option value="travel">Travel</option>
-                                <option value="entertainment">Entertainment</option>
-                                <option value="utilities">Utilities</option>
-                                <option value="healthcare">Healthcare</option>
-                                <option value="education">Education</option>
-                                <option value="shopping">Shopping</option>
-                                <option value="subscription">Subscription</option>
-                                <option value="housing">Housing</option>
-                                <option value="salary">Salary</option>
-                                <option value="freelance">Freelance</option>
-                                <option value="investment">Investment</option>
-                                <option value="transfer">Transfer</option>
-                                <option value="wedding">Wedding</option>
-                                <option value="other">Other</option>
-                            </select>
                         </div>
                         <button id="clearFilters" class="filter-btn" data-i18n="dash.clearFilters">Clear Filters</button>
                     </div>
@@ -3268,34 +3256,25 @@
                         <div class="chart-type-toggle" role="group" data-i18n-aria-label="filter.chartType" aria-label="Chart type">
                             <button type="button" class="chart-type-btn active" data-type="bar" aria-pressed="true" data-i18n="filter.chartBar" data-i18n-title="filter.chartBar" title="Bar">Bar</button>
                             <button type="button" class="chart-type-btn" data-type="doughnut" aria-pressed="false" data-i18n="filter.chartDoughnut" data-i18n-title="filter.chartDoughnut" title="Doughnut">Doughnut</button>
+                            <button type="button" class="chart-type-btn" data-type="stacked" aria-pressed="false" data-i18n="filter.chartStacked" data-i18n-title="filter.chartStacked" title="Trend">Trend</button>
                         </div>
                         <canvas id="categoryChart"></canvas>
                         <div class="chart-empty-state" hidden data-i18n="chart.noData">No data for current filters</div>
                         <div class="chart-loading-overlay" hidden><div class="chart-skeleton"></div></div>
                     </div>
-                    <div class="chart-wrapper" data-chart="categoryStacked">
-                        <canvas id="categoryStackedChart"></canvas>
-                        <div class="chart-empty-state" hidden data-i18n="chart.noData">No data for current filters</div>
+                    <div class="chart-wrapper budget-panel" data-chart="budget" data-i18n-title="budget.panelHelp" title="Current calendar month, your budgets only — filters don't apply.">
+                        <div class="budget-panel-head">
+                            <h3 data-i18n="dash.budgetStatus">Budget status</h3>
+                            <span class="mono tiny muted" id="budgetPanelMonth"></span>
+                        </div>
+                        <div id="budgetStatusBody" class="budget-panel-body"></div>
+                        <button type="button" id="budgetPanelManageBtn" class="btn ghost budget-panel-manage" data-i18n="budget.manageLink">Manage budgets</button>
                         <div class="chart-loading-overlay" hidden><div class="chart-skeleton"></div></div>
                     </div>
                 </div>
             </section>
             <section class="entries-section">
                 <h2 data-i18n="dash.registeredEntries">Registered Entries</h2>
-                <div class="summary">
-                    <div class="summary-item">
-                        <span data-i18n="dash.totalIncome">Total Income</span>
-                        <span id="totalIncome">$0.00</span>
-                    </div>
-                    <div class="summary-item">
-                        <span data-i18n="dash.totalExpenses">Total Expenses</span>
-                        <span id="totalExpenses">$0.00</span>
-                    </div>
-                    <div class="summary-item">
-                        <span data-i18n="dash.netBalance">Net Balance</span>
-                        <span id="netBalance">$0.00</span>
-                    </div>
-                </div>
                 <div class="entries-table">
                     <div id="entriesTableLoadingOverlay" class="table-loading-overlay" hidden role="status" aria-live="polite">
                         <span class="spinner-dot" aria-hidden="true"></span>

--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
             top: 0;
             z-index: 300;
             background: var(--primary);
-            color: #fff;
+            color: var(--on-primary);
             padding: 10px 16px;
             border-radius: 0 0 var(--radius-md) 0;
             font-size: 13px;
@@ -846,7 +846,7 @@
         }
         .quick-range-btn.active {
             background: var(--primary);
-            color: #fff;
+            color: var(--on-primary);
             border-color: transparent;
         }
 
@@ -2271,7 +2271,7 @@
         .chat-message-user {
             align-self: flex-end;
             background: var(--primary);
-            color: #fff;
+            color: var(--on-primary);
         }
         .chat-message-assistant {
             align-self: flex-start;
@@ -2497,7 +2497,7 @@
             border: none;
             border-radius: 0.4rem;
             background: var(--positive);
-            color: #fff;
+            color: var(--on-primary);
             font-weight: 600;
             font-size: 0.78rem;
             cursor: pointer;

--- a/index.html
+++ b/index.html
@@ -2189,7 +2189,7 @@
             background: var(--card);
             border: 1px solid var(--line);
             border-radius: var(--radius-lg);
-            box-shadow: 0 12px 32px rgba(38, 32, 26, 0.16);
+            box-shadow: var(--shadow-lg);
             flex-direction: column;
             overflow: hidden;
         }
@@ -2204,10 +2204,10 @@
             border-bottom: 1px solid var(--line);
         }
         .chat-header-title {
-            font-family: var(--serif);
-            font-size: 18px;
+            font-family: var(--display);
+            font-size: 15px;
             line-height: 1;
-            font-weight: 400;
+            font-weight: 600;
             color: var(--ink);
             letter-spacing: -0.01em;
         }
@@ -2222,7 +2222,7 @@
             border-radius: 0.25rem;
             transition: color 0.15s;
         }
-        .chat-close-btn:hover { color: var(--color-text-primary, #e0e0e8); }
+        .chat-close-btn:hover { color: var(--ink); }
 
         .chat-messages {
             flex: 1;
@@ -2244,31 +2244,34 @@
         }
         .chat-message-user {
             align-self: flex-end;
-            background: linear-gradient(135deg, #f59e0b, #d97706);
-            color: #1a1a2e;
+            background: var(--primary);
+            color: #fff;
         }
         .chat-message-assistant {
             align-self: flex-start;
-            background: var(--color-bg-surface, #2a2a3e);
-            color: var(--color-text-primary, #e0e0e8);
-            border: 1px solid var(--color-border, #333);
+            background: var(--bg-2);
+            color: var(--ink);
+            border: 1px solid var(--line);
         }
         .chat-message-assistant h3,
         .chat-message-assistant h4 {
             margin: 0.4rem 0 0.2rem;
             font-size: 0.88rem;
-            color: var(--color-accent-primary, #f59e0b);
+            font-weight: 600;
+            color: var(--ink);
         }
         .chat-message-assistant h4 { font-size: 0.82rem; }
-        .chat-message-assistant strong { color: var(--color-accent-primary, #f59e0b); }
+        .chat-message-assistant strong { color: var(--ink); font-weight: 600; }
+        .chat-message-assistant a { color: var(--primary); }
         .chat-message-assistant ul,
         .chat-message-assistant ol { margin: 0.3rem 0; padding-left: 1.25rem; }
         .chat-message-assistant li { margin-bottom: 0.15rem; }
         .chat-message-assistant code {
-            background: rgba(0,0,0,0.3);
+            background: var(--chip);
             padding: 0.1rem 0.35rem;
             border-radius: 0.2rem;
             font-size: 0.8rem;
+            font-family: var(--mono);
         }
         /* Markdown tables inside chat */
         .chat-md-table-wrap {
@@ -2282,37 +2285,38 @@
             width: 100%;
             border-collapse: collapse;
             font-size: 0.78rem;
-            border: 1px solid rgba(148, 163, 184, 0.15);
-            background: rgba(0, 0, 0, 0.2);
+            border: 1px solid var(--line);
+            background: var(--card);
         }
         .chat-md-table th {
-            background: rgba(245, 158, 11, 0.12);
-            color: var(--color-accent-primary, #f59e0b);
+            background: var(--bg-2);
+            color: var(--ink-2);
+            font-family: var(--mono);
             padding: 0.4rem 0.65rem;
             text-align: left;
             font-weight: 600;
-            font-size: 0.7rem;
+            font-size: 0.68rem;
             text-transform: uppercase;
             letter-spacing: 0.04em;
-            border-bottom: 1px solid rgba(245, 158, 11, 0.2);
+            border-bottom: 1px solid var(--line);
             white-space: nowrap;
         }
         .chat-md-table td {
             padding: 0.35rem 0.65rem;
-            border-bottom: 1px solid rgba(148, 163, 184, 0.07);
-            color: var(--color-text-primary, #e0e0e8);
+            border-bottom: 1px solid color-mix(in oklab, var(--line) 55%, var(--card));
+            color: var(--ink);
             white-space: nowrap;
         }
         .chat-md-table tr:last-child td {
             border-bottom: none;
         }
         .chat-md-table tr:hover td {
-            background: rgba(245, 158, 11, 0.04);
+            background: rgba(0, 0, 0, 0.02);
         }
         /* Fenced code blocks inside chat */
         .chat-message-assistant pre {
-            background: rgba(0, 0, 0, 0.35);
-            border: 1px solid rgba(148, 163, 184, 0.1);
+            background: var(--chip);
+            border: 1px solid var(--line);
             border-radius: 0.4rem;
             padding: 0.65rem 0.85rem;
             overflow-x: auto;
@@ -2323,8 +2327,8 @@
             background: none;
             padding: 0;
             font-size: 0.78rem;
-            font-family: 'Courier New', Courier, monospace;
-            color: var(--color-text-primary, #e0e0e8);
+            font-family: var(--mono);
+            color: var(--ink);
         }
 
         .chat-input-area {
@@ -2374,14 +2378,14 @@
             display: flex;
             gap: 0.3rem;
             padding: 0.6rem 0.85rem;
-            background: var(--color-bg-surface, #2a2a3e);
-            border: 1px solid var(--color-border, #333);
+            background: var(--bg-2);
+            border: 1px solid var(--line);
             border-radius: 0.75rem;
         }
         .chat-loading-dot {
             width: 0.45rem;
             height: 0.45rem;
-            background: var(--color-text-secondary, #a0a0b0);
+            background: var(--ink-3);
             border-radius: 50%;
             animation: chatDotBounce 1.2s infinite;
         }
@@ -2395,9 +2399,9 @@
         .chat-confirm-card {
             align-self: flex-start;
             max-width: 85%;
-            border: 1px solid var(--color-accent-primary, #f59e0b);
+            border: 1px solid color-mix(in oklab, var(--primary) 45%, var(--line));
             border-radius: 0.75rem;
-            background: var(--color-bg-surface, #2a2a3e);
+            background: var(--card);
             padding: 0.85rem 1rem;
             font-size: 0.82rem;
             line-height: 1.45;
@@ -2405,21 +2409,22 @@
         .chat-confirm-title {
             text-transform: uppercase;
             font-size: 0.7rem;
-            font-weight: 700;
+            font-weight: 600;
+            font-family: var(--mono);
             letter-spacing: 0.05em;
-            color: var(--color-accent-primary, #f59e0b);
+            color: var(--primary);
             margin-bottom: 0.6rem;
         }
         .chat-confirm-entry {
-            background: rgba(0,0,0,0.2);
+            background: var(--bg-2);
             border-radius: 0.4rem;
             padding: 0.5rem 0.65rem;
             margin-bottom: 0.6rem;
-            color: var(--color-text-secondary, #a0a0b0);
+            color: var(--ink-2);
             font-size: 0.78rem;
         }
         .chat-confirm-entry strong {
-            color: var(--color-text-primary, #e0e0e8);
+            color: var(--ink);
         }
         .chat-confirm-changes {
             display: flex;
@@ -2436,24 +2441,23 @@
         }
         .chat-confirm-change-label {
             font-weight: 600;
-            color: var(--color-text-secondary, #a0a0b0);
+            color: var(--ink-2);
             min-width: 5rem;
         }
         .chat-confirm-change-current {
             text-decoration: line-through;
-            color: var(--color-text-secondary, #a0a0b0);
-            opacity: 0.7;
+            color: var(--ink-3);
         }
         .chat-confirm-change-arrow {
-            color: var(--color-text-secondary, #a0a0b0);
-            opacity: 0.5;
+            color: var(--ink-3);
+            opacity: 0.6;
         }
         .chat-confirm-change-new {
-            color: #34d399;
+            color: var(--positive);
             font-weight: 600;
         }
         .chat-confirm-entry-group + .chat-confirm-entry-group {
-            border-top: 1px solid var(--color-border, #333);
+            border-top: 1px solid var(--line);
             margin-top: 0.6rem;
             padding-top: 0.6rem;
         }
@@ -2466,7 +2470,7 @@
             padding: 0.45rem 0.75rem;
             border: none;
             border-radius: 0.4rem;
-            background: linear-gradient(135deg, #34d399, #059669);
+            background: var(--positive);
             color: #fff;
             font-weight: 600;
             font-size: 0.78rem;
@@ -2476,11 +2480,11 @@
         .chat-confirm-btn:hover { opacity: 0.9; }
         .chat-confirm-btn:disabled { opacity: 0.5; cursor: not-allowed; }
         .chat-confirm-btn--danger {
-            background: linear-gradient(135deg, #f87171, #dc2626);
+            background: var(--negative);
         }
         .chat-confirm-warning {
             font-size: 0.72rem;
-            color: #fca5a5;
+            color: var(--negative);
             margin-top: 0.4rem;
             display: flex;
             align-items: center;
@@ -2489,7 +2493,7 @@
         .chat-confirm-progress {
             margin-top: 0.45rem;
             font-size: 0.75rem;
-            color: var(--color-text-secondary, #a0a0b0);
+            color: var(--ink-3);
             font-style: italic;
             text-align: center;
         }
@@ -2498,16 +2502,16 @@
             max-width: 90%;
             margin: 0.25rem 0 0.1rem;
             padding: 0.4rem 0.6rem;
-            background: rgba(99, 102, 241, 0.08);
-            border: 1px solid rgba(99, 102, 241, 0.25);
+            background: color-mix(in oklab, var(--info) 7%, var(--card));
+            border: 1px solid color-mix(in oklab, var(--info) 30%, var(--card));
             border-radius: 0.5rem;
             font-size: 0.72rem;
-            color: var(--color-text-secondary, #a0a0b0);
+            color: var(--ink-2);
         }
         .chat-tools-summary {
             cursor: pointer;
             font-weight: 600;
-            color: #818cf8;
+            color: var(--info);
             list-style: none;
             display: flex;
             align-items: center;
@@ -2536,36 +2540,36 @@
             align-items: baseline;
             gap: 0.3rem;
             padding: 0.2rem 0.35rem;
-            border-left: 2px solid #818cf8;
-            background: rgba(255, 255, 255, 0.02);
+            border-left: 2px solid var(--info);
+            background: var(--bg-2);
             border-radius: 0.25rem;
         }
-        .chat-tools-item--error { border-left-color: #ef4444; }
-        .chat-tools-item--pending { border-left-color: #f59e0b; }
+        .chat-tools-item--error { border-left-color: var(--negative); }
+        .chat-tools-item--pending { border-left-color: var(--warning); }
         .chat-tools-name {
-            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-            color: #c7d2fe;
+            font-family: var(--mono);
+            color: var(--info);
             font-weight: 600;
         }
         .chat-tools-args {
-            color: var(--color-text-secondary, #a0a0b0);
-            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+            color: var(--ink-3);
+            font-family: var(--mono);
             font-size: 0.68rem;
         }
-        .chat-tools-result { color: #86efac; }
-        .chat-tools-error { color: #fca5a5; }
+        .chat-tools-result { color: var(--positive); }
+        .chat-tools-error { color: var(--negative); }
         .chat-tools-duration {
             margin-left: auto;
-            color: #6b7280;
+            color: var(--ink-3);
             font-size: 0.65rem;
         }
         .chat-cancel-btn {
             flex: 1;
             padding: 0.45rem 0.75rem;
-            border: 1px solid var(--color-border, #333);
+            border: 1px solid var(--line);
             border-radius: 0.4rem;
             background: transparent;
-            color: var(--color-text-secondary, #a0a0b0);
+            color: var(--ink-2);
             font-weight: 600;
             font-size: 0.78rem;
             cursor: pointer;
@@ -2582,19 +2586,19 @@
             font-weight: 500;
         }
         .chat-confirm-result--success {
-            background: rgba(52, 211, 153, 0.15);
-            color: #34d399;
-            border: 1px solid rgba(52, 211, 153, 0.3);
+            background: color-mix(in oklab, var(--positive) 14%, var(--card));
+            color: var(--positive);
+            border: 1px solid color-mix(in oklab, var(--positive) 35%, var(--card));
         }
         .chat-confirm-result--error {
-            background: rgba(239, 68, 68, 0.15);
-            color: #ef4444;
-            border: 1px solid rgba(239, 68, 68, 0.3);
+            background: color-mix(in oklab, var(--negative) 14%, var(--card));
+            color: var(--negative);
+            border: 1px solid color-mix(in oklab, var(--negative) 35%, var(--card));
         }
         .chat-confirm-result--info {
-            background: rgba(160, 160, 176, 0.1);
-            color: var(--color-text-secondary, #a0a0b0);
-            border: 1px solid var(--color-border, #333);
+            background: var(--bg-2);
+            color: var(--ink-2);
+            border: 1px solid var(--line);
         }
 
         @media (max-width: 768px) {
@@ -2702,7 +2706,7 @@
     <button class="lang-toggle" data-i18n-title="lang.switch.title" onclick="setLang(getLang()==='en'?'pt':'en')" aria-label="Toggle language">🌐</button>
 
     <!-- AI Chat Widget -->
-    <button id="chatFab" class="chat-fab" data-i18n-title="chat.title" data-i18n-aria-label="chat.title">
+    <button id="chatFab" class="chat-fab" aria-expanded="false" aria-controls="chatWindow" data-i18n-title="chat.title" data-i18n-aria-label="chat.title">
         <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
     </button>
     <div id="chatWindow" class="chat-window">

--- a/js/app.js
+++ b/js/app.js
@@ -45,7 +45,14 @@ function setUserCategories(list) {
 
 function categoryColor(slug) {
     const c = _userCategoriesBySlug.get(slug);
-    return c ? c.color : ORPHAN_CATEGORY_COLOR;
+    // Render-boundary validation (defense in depth): colors are validated
+    // server-side at write time, but the value is interpolated into style
+    // attributes (tag/chip dots) and concatenated with an alpha suffix for
+    // Chart.js datasets — both assume a clean 6-digit hex. Anything else
+    // falls back to the neutral orphan color.
+    return (c && typeof c.color === 'string' && HEX_REGEX_FE.test(c.color))
+        ? c.color
+        : ORPHAN_CATEGORY_COLOR;
 }
 
 function categoryLabel(slug) {
@@ -3382,6 +3389,11 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // Shared by the Budgets modal and the dashboard budget panel.
+    // Only interpolate server-provided category colors into style attributes
+    // when they're a clean 6-digit hex — escapeHtml alone doesn't stop CSS
+    // injection (a payload needs no quotes or angle brackets inside style).
+    const safeCategoryHex = (color) =>
+        (typeof color === 'string' && HEX_REGEX_FE.test(color)) ? color : null;
     // Safe progress: null pct when no target. Cap at 100% for the bar fill
     // but keep the raw ratio so callers can surface an "over budget" pill.
     const budgetProgressFor = (amount, actual) => {
@@ -3475,7 +3487,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 : '';
             const swatch = isOverall
                 ? `<span style="display:inline-block; width:10px; height:10px; border-radius:2px; background: var(--ink); margin-right: 6px;"></span>`
-                : `<span style="display:inline-block; width:10px; height:10px; border-radius:2px; background: ${escapeHtml(color || 'var(--ink-3)')}; margin-right: 6px;"></span>`;
+                : `<span style="display:inline-block; width:10px; height:10px; border-radius:2px; background: ${safeCategoryHex(color) || 'var(--ink-3)'}; margin-right: 6px;"></span>`;
             const inputDisabled = isOrphan ? 'disabled' : '';
             const clearDisabled = (amount > 0) ? '' : 'disabled';
 
@@ -3670,7 +3682,8 @@ document.addEventListener('DOMContentLoaded', () => {
             const overPill = p.over ? ` <span class="delta-pill down">${escapeHtml(t('budget.overBudget'))}</span>` : '';
             const pct = p.pct == null ? '' : ' · ' + (p.over ? p.raw : p.pct).toFixed(0) + '%';
             const dot = isOverall ? '' : '<i class="budget-dot" aria-hidden="true"></i>';
-            const dotColor = color ? ` style="--budget-dot-color: ${escapeHtml(color)}"` : '';
+            const safeColor = safeCategoryHex(color);
+            const dotColor = safeColor ? ` style="--budget-dot-color: ${safeColor}"` : '';
             return `
                 <div class="budget-row${isOverall ? ' budget-row--overall' : ''}">
                     <div class="budget-row-top">

--- a/js/app.js
+++ b/js/app.js
@@ -310,15 +310,15 @@ function _chartFontFamily() {
     return (v && v.trim()) || "Geist, ui-sans-serif, system-ui, sans-serif";
 }
 
-// Serif counterpart for chart titles — tracks --serif so editorial vs.
-// modern vs. system typography presets reach the chart titles too.
+// Display-face counterpart for chart titles — tracks --display so the
+// default (Ledger) vs. system typography presets reach the chart titles too.
 function _chartSerifFamily() {
-    const v = getComputedStyle(document.documentElement).getPropertyValue('--serif');
-    return (v && v.trim()) || "'Instrument Serif', Georgia, serif";
+    const v = getComputedStyle(document.documentElement).getPropertyValue('--display');
+    return (v && v.trim()) || "'Bricolage Grotesque', ui-sans-serif, sans-serif";
 }
 
 // Read theme palette from CSS custom properties so chart colors track the
-// active design system (warm earthy "Clay & Sand"). Falls back to the
+// active design system (Ledger — Paper/Graphite). Falls back to the
 // hard-coded defaults if a variable is missing — keeps Chart.js happy when
 // the page is rendered before the stylesheet has fully resolved.
 function readThemePalette() {
@@ -331,7 +331,7 @@ function readThemePalette() {
     // accent fill ourselves by parsing the hex token to rgba.
     const hexToRgba = (hex, alpha) => {
         const m = /^#?([0-9a-f]{3}|[0-9a-f]{6})$/i.exec((hex || '').trim());
-        if (!m) return 'rgba(184, 89, 58, ' + alpha + ')';
+        if (!m) return 'rgba(15, 107, 79, ' + alpha + ')';
         let h = m[1];
         if (h.length === 3) h = h[0] + h[0] + h[1] + h[1] + h[2] + h[2];
         const r = parseInt(h.slice(0, 2), 16);
@@ -339,27 +339,29 @@ function readThemePalette() {
         const b = parseInt(h.slice(4, 6), 16);
         return 'rgba(' + r + ', ' + g + ', ' + b + ', ' + alpha + ')';
     };
-    const primary = v('--primary', '#B8593A');
-    const negative = v('--negative', primary);
-    const positive = v('--positive', '#6B8248');
-    const accent1 = v('--accent-1', '#7A8450');
-    const accent2 = v('--accent-2', '#C89A3E');
+    const primary = v('--primary', '#0F6B4F');
+    const negative = v('--negative', '#C2452D');
+    const positive = v('--positive', '#1B7A57');
+    const accent1 = v('--accent-1', positive);
+    const accent2 = v('--accent-2', '#B07A1F');
     // Chart.js wants a concrete font-family string — pull it from --sans so
     // chart legends/ticks track the active typography preset.
     const sansFamily = v('--sans', "'Geist', sans-serif");
     return {
-        textPrimary: v('--ink', '#26201A'),
-        textSecondary: v('--ink-2', '#5A4E3F'),
-        textMuted: v('--ink-3', '#8A7A65'),
-        gridColor: v('--line', '#DDD0B8'),
-        cardBg: v('--card', '#FBF6EC'),
+        textPrimary: v('--ink', '#191C21'),
+        textSecondary: v('--ink-2', '#50555E'),
+        textMuted: v('--ink-3', '#6E747F'),
+        gridColor: v('--line', '#E3E3DE'),
+        cardBg: v('--card', '#FFFFFF'),
         accent: primary,
         accentGlow: hexToRgba(primary, 0.22),
         success: positive,
         danger: negative,
         olive: accent1,
         ochre: accent2,
-        primarySoft: v('--primary-soft', '#E8BFAB'),
+        warning: v('--warning', '#B07A1F'),
+        info: v('--info', '#3B6E8F'),
+        primarySoft: v('--primary-soft', '#D7EBE2'),
         fontFamily: sansFamily,
     };
 }
@@ -3891,16 +3893,14 @@ document.addEventListener('DOMContentLoaded', () => {
                         <label style="display: flex; flex-direction: column; gap: 0.35rem;">
                             <span style="font-size: 0.85rem; color: var(--color-text-muted);">${t('settings.themeLabel')}</span>
                             <select id="settingsThemeSelect" style="padding: 0.5rem; background: var(--color-bg-base); border: 1px solid var(--color-border); border-radius: 8px; color: var(--color-text-primary); font-family: var(--font-body);">
-                                <option value="earthy">${t('settings.themeEarthy')}</option>
+                                <option value="paper">${t('settings.themePaper')}</option>
                                 <option value="dark">${t('settings.themeDark')}</option>
-                                <option value="light">${t('settings.themeLight')}</option>
                             </select>
                         </label>
                         <label style="display: flex; flex-direction: column; gap: 0.35rem;">
                             <span style="font-size: 0.85rem; color: var(--color-text-muted);">${t('settings.typographyLabel')}</span>
                             <select id="settingsTypographySelect" style="padding: 0.5rem; background: var(--color-bg-base); border: 1px solid var(--color-border); border-radius: 8px; color: var(--color-text-primary); font-family: var(--font-body);">
-                                <option value="editorial">${t('settings.typographyEditorial')}</option>
-                                <option value="modern">${t('settings.typographyModern')}</option>
+                                <option value="default">${t('settings.typographyDefault')}</option>
                                 <option value="system">${t('settings.typographySystem')}</option>
                             </select>
                         </label>
@@ -3934,28 +3934,27 @@ document.addEventListener('DOMContentLoaded', () => {
         const typoSel = overlay.querySelector('#settingsTypographySelect');
         if (!themeSel || !typoSel) return;
         // Default values match the dataset attributes the early-bootstrap
-        // script applied to <html> on page load.
-        themeSel.value = document.documentElement.getAttribute('data-theme') || 'earthy';
-        typoSel.value = document.documentElement.getAttribute('data-typography') || 'editorial';
+        // script applied to <html> on page load. An explicit choice is always
+        // persisted so the OS-preference fallback stops applying once the
+        // user has picked a theme.
+        themeSel.value = document.documentElement.getAttribute('data-theme') === 'dark' ? 'dark' : 'paper';
+        typoSel.value = document.documentElement.getAttribute('data-typography') === 'system' ? 'system' : 'default';
 
         themeSel.addEventListener('change', () => {
             const v = themeSel.value;
-            try {
-                if (v === 'earthy') localStorage.removeItem('appTheme');
-                else localStorage.setItem('appTheme', v);
-            } catch (e) {}
-            if (v === 'earthy') document.documentElement.removeAttribute('data-theme');
-            else document.documentElement.setAttribute('data-theme', v);
+            try { localStorage.setItem('appTheme', v); } catch (e) {}
+            if (v === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
+            else document.documentElement.removeAttribute('data-theme');
             reapplyChartTheme();
         });
 
         typoSel.addEventListener('change', () => {
             const v = typoSel.value;
             try {
-                if (v === 'editorial') localStorage.removeItem('appTypography');
+                if (v === 'default') localStorage.removeItem('appTypography');
                 else localStorage.setItem('appTypography', v);
             } catch (e) {}
-            if (v === 'editorial') document.documentElement.removeAttribute('data-typography');
+            if (v === 'default') document.documentElement.removeAttribute('data-typography');
             else document.documentElement.setAttribute('data-typography', v);
             reapplyChartTheme();
         });

--- a/js/app.js
+++ b/js/app.js
@@ -88,6 +88,9 @@ let categoryChart = null;
 // Categories chart supports three presentations: horizontal bar (default),
 // doughnut, and stacked monthly bars ('stacked').
 let currentCategoryChartType = 'bar';
+// Average-line annotations on the income/expense chart (user-toggleable,
+// persisted under 'assetmgmt.showAvgLines'; default on).
+let showAvgLines = true;
 let _categoryCtxRef = null; // kept so setCategoryChartType can rebuild without re-running initializeCharts
 let _chartThemeRef = null;  // theme/color palette reference for rebuilds
 // Add a variable to track currently filtered entries
@@ -776,7 +779,8 @@ function updateCharts(entriesToShow = entries, forceDefaultMonths = false, filte
     incomeVsExpenseChart.data.datasets[1].data = expenseValues;
 
     // Add average lines when 2+ months are selected (only show if average > 0)
-    if (months.length >= 2) {
+    // and the user hasn't toggled them off via the Avg button on the chart.
+    if (months.length >= 2 && showAvgLines) {
         const avgIncome = incomeValues.reduce((a, b) => a + b, 0) / months.length;
         const avgExpense = expenseValues.reduce((a, b) => a + b, 0) / months.length;
 
@@ -2888,6 +2892,19 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     });
 
+    // Select every category chip at once — useful for "all except a few":
+    // select all, then untick the unwanted ones.
+    const selectAllCatsBtn = document.getElementById('selectAllCategories');
+    if (selectAllCatsBtn) {
+        selectAllCatsBtn.addEventListener('click', () => {
+            filterState.categories = categorySlugList().slice();
+            renderCategoryChips();
+            saveFilterState();
+            renderActiveFiltersBar();
+            filterEntries();
+        });
+    }
+
     // Filter controls - only clear button now, apply is handled by dynamic listeners
     document.getElementById('clearFilters').addEventListener('click', () => {
         filterState = freshFilterState();
@@ -3165,14 +3182,16 @@ document.addEventListener('DOMContentLoaded', () => {
         else if (mq.addListener) mq.addListener(handleBreakpoint);
     }
 
-    // Categories chart type toggle (bar / doughnut / stacked)
-    document.querySelectorAll('.chart-type-toggle .chart-type-btn').forEach(btn => {
+    // Categories chart type toggle (bar / doughnut / stacked). Scoped to
+    // [data-type] buttons and to the button's own group so it doesn't
+    // interfere with the standalone Avg toggle on the cash-flow chart.
+    document.querySelectorAll('.chart-type-toggle .chart-type-btn[data-type]').forEach(btn => {
         // Sync initial aria-pressed from the pre-set .active class in HTML.
         btn.setAttribute('aria-pressed', String(btn.classList.contains('active')));
         btn.addEventListener('click', () => {
             const type = btn.dataset.type;
             setCategoryChartType(type);
-            document.querySelectorAll('.chart-type-toggle .chart-type-btn').forEach(b => {
+            btn.parentElement.querySelectorAll('.chart-type-btn').forEach(b => {
                 const isActive = b === btn;
                 b.classList.toggle('active', isActive);
                 b.setAttribute('aria-pressed', String(isActive));
@@ -3180,6 +3199,26 @@ document.addEventListener('DOMContentLoaded', () => {
             try { localStorage.setItem('assetmgmt.categoryChartType', type); } catch {}
         });
     });
+
+    // Avg-lines toggle on the income/expense chart — an on/off switch, not
+    // a mutually-exclusive group like the category toggle above.
+    const avgLinesToggleBtn = document.getElementById('avgLinesToggle');
+    if (avgLinesToggleBtn) {
+        try {
+            if (localStorage.getItem('assetmgmt.showAvgLines') === '0') showAvgLines = false;
+        } catch {}
+        avgLinesToggleBtn.classList.toggle('active', showAvgLines);
+        avgLinesToggleBtn.setAttribute('aria-pressed', String(showAvgLines));
+        avgLinesToggleBtn.addEventListener('click', () => {
+            showAvgLines = !showAvgLines;
+            avgLinesToggleBtn.classList.toggle('active', showAvgLines);
+            avgLinesToggleBtn.setAttribute('aria-pressed', String(showAvgLines));
+            try { localStorage.setItem('assetmgmt.showAvgLines', showAvgLines ? '1' : '0'); } catch {}
+            if (Array.isArray(currentFilteredEntries)) {
+                updateCharts(currentFilteredEntries, false, filterState.start, filterState.end);
+            }
+        });
+    }
 
     // ============ REPORTS MODAL (issue #92) ============
     //

--- a/js/app.js
+++ b/js/app.js
@@ -85,8 +85,8 @@ let entries = [];
 let monthlyBalanceChart = null;
 let incomeVsExpenseChart = null;
 let categoryChart = null;
-let categoryStackedChart = null;
-// Category chart supports two presentations: horizontal bar (default) and doughnut.
+// Categories chart supports three presentations: horizontal bar (default),
+// doughnut, and stacked monthly bars ('stacked').
 let currentCategoryChartType = 'bar';
 let _categoryCtxRef = null; // kept so setCategoryChartType can rebuild without re-running initializeCharts
 let _chartThemeRef = null;  // theme/color palette reference for rebuilds
@@ -107,12 +107,13 @@ let currentPage = 1;
 let currentViewMode = 'individual';
 let hasPartner = false;
 
-// Build the category-distribution chart as either horizontal bar or doughnut.
-// Colors are applied in updateCharts() (sorted by value) so they stay consistent
-// with CATEGORY_COLORS regardless of sort order.
+// Build the categories chart in one of three presentations: horizontal bar
+// (aggregate distribution, default), doughnut (same data as shares) or
+// stacked monthly bars (trend over time). Colors/data are applied in
+// updateCharts() so they stay consistent regardless of presentation.
 function buildCategoryChart(ctx, type, colors) {
     const commonTooltip = {
-        backgroundColor: colors.cardBg || '#FBF6EC',
+        backgroundColor: colors.cardBg || '#FFFFFF',
         titleColor: colors.textPrimary,
         bodyColor: colors.textSecondary,
         borderColor: colors.gridColor,
@@ -122,11 +123,79 @@ function buildCategoryChart(ctx, type, colors) {
     };
     const title = {
         display: true,
-        text: t('chart.expensesByCategory'),
+        text: type === 'stacked' ? t('chart.expenseCatByMonth') : t('chart.expensesByCategory'),
         color: colors.textPrimary,
-        font: { size: 14, weight: '500', family: _chartSerifFamily() },
+        font: { size: 14, weight: '600', family: _chartSerifFamily() },
         padding: { bottom: 20 }
     };
+    const axisTitle = (text) => ({
+        display: true,
+        text: text,
+        color: colors.textSecondary,
+        font: { family: _chartFontFamily(), size: 11, weight: '500' },
+        padding: { top: 6, bottom: 0 }
+    });
+    if (type === 'stacked') {
+        // Stacked monthly bars — expenses by category per month. Datasets are
+        // rebuilt on every updateCharts() call from the user's category list
+        // (plus any orphan slugs in the filtered data).
+        return new Chart(ctx, {
+            type: 'bar',
+            data: { labels: [], datasets: [] },
+            options: {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: {
+                        position: 'bottom',
+                        labels: {
+                            color: colors.textSecondary,
+                            font: { size: 10, family: _chartFontFamily() },
+                            boxWidth: 12,
+                            padding: 10
+                        }
+                    },
+                    title,
+                    tooltip: {
+                        ...commonTooltip,
+                        callbacks: {
+                            label: function(context) {
+                                const label = context.dataset.label || '';
+                                const value = context.parsed.y;
+                                return `${label}: $${value.toFixed(2)}`;
+                            }
+                        }
+                    }
+                },
+                scales: {
+                    x: {
+                        stacked: true,
+                        title: axisTitle(t('chart.axisMonth')),
+                        grid: { color: colors.gridColor, drawBorder: false },
+                        ticks: {
+                            color: colors.textMuted,
+                            maxRotation: 45,
+                            minRotation: 45,
+                            font: { family: _chartFontFamily() }
+                        }
+                    },
+                    y: {
+                        stacked: true,
+                        beginAtZero: true,
+                        title: axisTitle(t('chart.axisAmount')),
+                        grid: { color: colors.gridColor, drawBorder: false },
+                        ticks: {
+                            color: colors.textMuted,
+                            font: { family: _chartFontFamily() },
+                            callback: function(value) {
+                                return '$' + value.toFixed(0);
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
     if (type === 'doughnut') {
         return new Chart(ctx, {
             type: 'doughnut',
@@ -256,7 +325,7 @@ let _categoryRebuildTimer = null;
 let _themeRebuildTimer = null;
 
 function setCategoryChartType(type) {
-    if (!['bar', 'doughnut'].includes(type)) return;
+    if (!['bar', 'doughnut', 'stacked'].includes(type)) return;
     if (type === currentCategoryChartType) return;
     currentCategoryChartType = type;
     // Show the loading skeleton on the category chart and defer the
@@ -290,10 +359,10 @@ function reapplyChartTheme() {
     if (_themeRebuildTimer) clearTimeout(_themeRebuildTimer);
     _themeRebuildTimer = setTimeout(() => {
         _themeRebuildTimer = null;
-        [monthlyBalanceChart, incomeVsExpenseChart, categoryChart, categoryStackedChart].forEach(c => {
+        [monthlyBalanceChart, incomeVsExpenseChart, categoryChart].forEach(c => {
             if (c) c.destroy();
         });
-        monthlyBalanceChart = incomeVsExpenseChart = categoryChart = categoryStackedChart = null;
+        monthlyBalanceChart = incomeVsExpenseChart = categoryChart = null;
         initializeCharts();
         if (Array.isArray(currentFilteredEntries)) {
             updateCharts(currentFilteredEntries, false, filterState.start, filterState.end);
@@ -354,7 +423,7 @@ function readThemePalette() {
         gridColor: v('--line', '#E3E3DE'),
         cardBg: v('--card', '#FFFFFF'),
         accent: primary,
-        accentGlow: hexToRgba(primary, 0.22),
+        accentGlow: hexToRgba(primary, 0.10),
         success: positive,
         danger: negative,
         olive: accent1,
@@ -371,7 +440,6 @@ function initializeCharts() {
     const monthlyBalanceCtx = document.getElementById('monthlyBalanceChart').getContext('2d');
     const incomeVsExpenseCtx = document.getElementById('incomeVsExpenseChart').getContext('2d');
     const categoryCtx = document.getElementById('categoryChart').getContext('2d');
-    const categoryStackedCtx = document.getElementById('categoryStackedChart').getContext('2d');
 
     const colors = readThemePalette();
 
@@ -524,9 +592,11 @@ function initializeCharts() {
                 pointBackgroundColor: colors.accent,
                 pointBorderColor: colors.cardBg,
                 pointBorderWidth: 2,
-                pointRadius: 5,
-                pointHoverRadius: 7,
-                borderWidth: 3
+                // Quiet line: no dots along the series, one marker on the
+                // latest point so the current position stays anchored.
+                pointRadius: (ctx) => ctx.dataIndex === ctx.dataset.data.length - 1 ? 4 : 0,
+                pointHoverRadius: 6,
+                borderWidth: 2
             }]
         },
         options: {
@@ -569,19 +639,19 @@ function initializeCharts() {
                 {
                     label: t('chart.income'),
                     data: [],
-                    backgroundColor: colors.olive,
-                    borderColor: colors.olive,
-                    borderWidth: 2,
-                    borderRadius: 6,
+                    backgroundColor: colors.success + 'cc',
+                    borderColor: colors.success,
+                    borderWidth: 1,
+                    borderRadius: 4,
                     hoverBackgroundColor: colors.success
                 },
                 {
                     label: t('chart.expenses'),
                     data: [],
-                    backgroundColor: colors.accent,
-                    borderColor: colors.accent,
-                    borderWidth: 2,
-                    borderRadius: 6,
+                    backgroundColor: colors.danger + 'cc',
+                    borderColor: colors.danger,
+                    borderWidth: 1,
+                    borderRadius: 4,
                     hoverBackgroundColor: colors.danger
                 }
             ]
@@ -589,90 +659,12 @@ function initializeCharts() {
         options: incomeExpenseOptions
     });
 
-    // Category distribution chart — supports bar (horizontal) or doughnut view.
+    // Categories chart — bar (aggregate), doughnut, or stacked monthly view.
     // The type can be toggled by the user via the overlay buttons; we rebuild
     // the chart on toggle because Chart.js does not allow changing `type` in place.
     _categoryCtxRef = categoryCtx;
     _chartThemeRef = colors;
     categoryChart = buildCategoryChart(categoryCtx, currentCategoryChartType, colors);
-
-    // Stacked bar chart for entry categories by month. Datasets are rebuilt
-    // dynamically on every updateCharts() call from the user's current
-    // category list (plus any orphan slugs in the filtered data), so adding
-    // / removing categories at runtime updates this chart automatically.
-    const stackedDatasets = [];
-
-    categoryStackedChart = new Chart(categoryStackedCtx, {
-        type: 'bar',
-        data: {
-            labels: [],
-            datasets: stackedDatasets
-        },
-        options: {
-            responsive: true,
-            maintainAspectRatio: false,
-            plugins: {
-                legend: {
-                    position: 'bottom',
-                    labels: {
-                        color: colors.textSecondary,
-                        font: { size: 10, family: _chartFontFamily() },
-                        boxWidth: 12,
-                        padding: 10
-                    }
-                },
-                title: {
-                    display: true,
-                    text: t('chart.expenseCatByMonth'),
-                    color: colors.textPrimary,
-                    font: { size: 14, weight: '600', family: _chartSerifFamily() },
-                    padding: { bottom: 15 }
-                },
-                tooltip: {
-                    backgroundColor: '#1e293b',
-                    titleColor: colors.textPrimary,
-                    bodyColor: colors.textSecondary,
-                    borderColor: 'rgba(148, 163, 184, 0.2)',
-                    borderWidth: 1,
-                    padding: 12,
-                    cornerRadius: 8,
-                    callbacks: {
-                        label: function(context) {
-                            const label = context.dataset.label || '';
-                            const value = context.parsed.y;
-                            return `${label}: $${value.toFixed(2)}`;
-                        }
-                    }
-                }
-            },
-            scales: {
-                x: {
-                    stacked: true,
-                    title: axisTitle(t('chart.axisMonth')),
-                    grid: { color: colors.gridColor, drawBorder: false },
-                    ticks: {
-                        color: colors.textMuted,
-                        maxRotation: 45,
-                        minRotation: 45,
-                        font: { family: _chartFontFamily() }
-                    }
-                },
-                y: {
-                    stacked: true,
-                    beginAtZero: true,
-                    title: axisTitle(t('chart.axisAmount')),
-                    grid: { color: colors.gridColor, drawBorder: false },
-                    ticks: {
-                        color: colors.textMuted,
-                        font: { family: _chartFontFamily() },
-                        callback: function(value) {
-                            return '$' + value.toFixed(0);
-                        }
-                    }
-                }
-            }
-        }
-    });
 }
 
 function getMonthLabelsAroundCurrent() {
@@ -793,14 +785,14 @@ function updateCharts(entriesToShow = entries, forceDefaultMonths = false, filte
                 type: 'line',
                 yMin: avgIncome,
                 yMax: avgIncome,
-                borderColor: themePalette.olive,
+                borderColor: themePalette.success,
                 borderWidth: 2,
                 borderDash: [6, 4],
                 label: {
                     display: true,
                     content: t('chart.avgIncome', { value: avgIncome.toFixed(0) }),
                     position: 'start',
-                    backgroundColor: themePalette.olive,
+                    backgroundColor: themePalette.success,
                     color: themePalette.cardBg,
                     font: { size: 11, family: _chartFontFamily() },
                     padding: 4
@@ -813,14 +805,14 @@ function updateCharts(entriesToShow = entries, forceDefaultMonths = false, filte
                 type: 'line',
                 yMin: avgExpense,
                 yMax: avgExpense,
-                borderColor: themePalette.accent,
+                borderColor: themePalette.danger,
                 borderWidth: 2,
                 borderDash: [6, 4],
                 label: {
                     display: true,
                     content: t('chart.avgExpenses', { value: avgExpense.toFixed(0) }),
                     position: 'end',
-                    backgroundColor: themePalette.accent,
+                    backgroundColor: themePalette.danger,
                     color: themePalette.cardBg,
                     font: { size: 11, family: _chartFontFamily() },
                     padding: 4
@@ -836,105 +828,109 @@ function updateCharts(entriesToShow = entries, forceDefaultMonths = false, filte
 
     incomeVsExpenseChart.update();
 
-    // Update category doughnut chart
-    const tagTotals = {};
-    entriesToShow
-        .filter(e => e.type === 'expense')
-        .forEach(entry => {
-            const entryTags = (entry.tags && entry.tags.length > 0) ? entry.tags : ['other'];
-            const perTagAmount = parseFloat(entry.amount) / entryTags.length;
-            entryTags.forEach(tag => {
-                tagTotals[tag] = (tagTotals[tag] || 0) + perTagAmount;
+    // Update the categories chart in whichever presentation is active.
+    // The chart instance always matches currentCategoryChartType because
+    // setCategoryChartType rebuilds it before re-running updateCharts.
+    let hasCategoryData;
+    if (currentCategoryChartType === 'stacked') {
+        // Stacked monthly view — expenses by category per month. Categories
+        // axis = user's current category list ∪ orphan slugs found in the
+        // filtered data. Orphans get the neutral fallback color.
+        const userSlugs = categorySlugList();
+        const orphanSlugs = new Set();
+        entriesToShow
+            .filter(e => e.type === 'expense')
+            .forEach(entry => {
+                const entryTags = (entry.tags && entry.tags.length > 0) ? entry.tags : ['other'];
+                entryTags.forEach(tag => {
+                    if (!_userCategoriesBySlug.has(tag)) orphanSlugs.add(tag);
+                });
             });
+        const stackedCategories = [...userSlugs, ...Array.from(orphanSlugs).sort()];
+
+        const categoryMonthlyData = {};
+        months.forEach(month => {
+            categoryMonthlyData[month] = {};
+            stackedCategories.forEach(cat => { categoryMonthlyData[month][cat] = 0; });
         });
-    const sortedTags = Object.entries(tagTotals).sort((a, b) => b[1] - a[1]);
-    const sortedCategoryKeys = sortedTags.map(([tag]) => tag);
-    const sortedColors = sortedCategoryKeys.map(categoryColor);
-    categoryChart.data.labels = sortedTags.map(([tag]) => categoryLabel(tag));
-    const categoryValues = sortedTags.map(([, amount]) => Math.round(amount * 100) / 100);
-    categoryChart.data.datasets[0].data = categoryValues;
-    categoryChart.data.datasets[0].backgroundColor = sortedColors.map(c => c + 'cc');
-    categoryChart.data.datasets[0].borderColor = sortedColors;
-    categoryChart.data.datasets[0].hoverBackgroundColor = sortedColors;
+
+        // Aggregate expense entries by month and category — preserve raw tag
+        // (including orphans) so deleted-then-recreated categories render
+        // correctly without bucketing into 'other'.
+        entriesToShow
+            .filter(e => e.type === 'expense')
+            .forEach(entry => {
+                const month = entry.month;
+                if (!categoryMonthlyData[month]) return;
+                const entryTags = (entry.tags && entry.tags.length > 0) ? entry.tags : ['other'];
+                const perTagAmount = parseFloat(entry.amount) / entryTags.length;
+                entryTags.forEach(tag => {
+                    if (categoryMonthlyData[month][tag] != null) {
+                        categoryMonthlyData[month][tag] += perTagAmount;
+                    }
+                });
+            });
+
+        categoryChart.data.labels = months;
+
+        const categoriesWithData = stackedCategories.filter(category =>
+            months.some(month => categoryMonthlyData[month][category] > 0)
+        );
+
+        // Rebuild datasets from scratch on every update so adding/removing
+        // categories at runtime stays in sync without re-creating the chart.
+        categoryChart.data.datasets = stackedCategories.map(category => {
+            const color = categoryColor(category);
+            return {
+                label: categoryLabel(category),
+                _category: category,
+                data: months.map(month => {
+                    const value = categoryMonthlyData[month]?.[category] || 0;
+                    return Math.round(value * 100) / 100;
+                }),
+                backgroundColor: color + 'cc',
+                borderColor: color,
+                borderWidth: 1,
+                borderRadius: 3,
+                hoverBackgroundColor: color,
+                hidden: !categoriesWithData.includes(category),
+            };
+        });
+        hasCategoryData = categoriesWithData.length > 0;
+    } else {
+        // Aggregate view (horizontal bar or doughnut) — expense totals per
+        // category across the window, sorted descending.
+        const tagTotals = {};
+        entriesToShow
+            .filter(e => e.type === 'expense')
+            .forEach(entry => {
+                const entryTags = (entry.tags && entry.tags.length > 0) ? entry.tags : ['other'];
+                const perTagAmount = parseFloat(entry.amount) / entryTags.length;
+                entryTags.forEach(tag => {
+                    tagTotals[tag] = (tagTotals[tag] || 0) + perTagAmount;
+                });
+            });
+        const sortedTags = Object.entries(tagTotals).sort((a, b) => b[1] - a[1]);
+        const sortedCategoryKeys = sortedTags.map(([tag]) => tag);
+        const sortedColors = sortedCategoryKeys.map(categoryColor);
+        categoryChart.data.labels = sortedTags.map(([tag]) => categoryLabel(tag));
+        const categoryValues = sortedTags.map(([, amount]) => Math.round(amount * 100) / 100);
+        categoryChart.data.datasets[0].data = categoryValues;
+        categoryChart.data.datasets[0].backgroundColor = sortedColors.map(c => c + 'cc');
+        categoryChart.data.datasets[0].borderColor = sortedColors;
+        categoryChart.data.datasets[0].hoverBackgroundColor = sortedColors;
+        hasCategoryData = categoryValues.length > 0 && categoryValues.some(v => v > 0);
+    }
     categoryChart.update();
-
-    // Update stacked category chart — expenses by category per month.
-    // Categories axis = user's current category list ∪ orphan slugs found
-    // in the filtered data. Orphans get the neutral fallback color.
-    const userSlugs = categorySlugList();
-    const orphanSlugs = new Set();
-    entriesToShow
-        .filter(e => e.type === 'expense')
-        .forEach(entry => {
-            const entryTags = (entry.tags && entry.tags.length > 0) ? entry.tags : ['other'];
-            entryTags.forEach(tag => {
-                if (!_userCategoriesBySlug.has(tag)) orphanSlugs.add(tag);
-            });
-        });
-    const stackedCategories = [...userSlugs, ...Array.from(orphanSlugs).sort()];
-
-    const categoryMonthlyData = {};
-    months.forEach(month => {
-        categoryMonthlyData[month] = {};
-        stackedCategories.forEach(cat => { categoryMonthlyData[month][cat] = 0; });
-    });
-
-    // Aggregate expense entries by month and category — preserve raw tag
-    // (including orphans) so deleted-then-recreated categories render
-    // correctly without bucketing into 'other'.
-    entriesToShow
-        .filter(e => e.type === 'expense')
-        .forEach(entry => {
-            const month = entry.month;
-            if (!categoryMonthlyData[month]) return;
-            const entryTags = (entry.tags && entry.tags.length > 0) ? entry.tags : ['other'];
-            const perTagAmount = parseFloat(entry.amount) / entryTags.length;
-            entryTags.forEach(tag => {
-                if (categoryMonthlyData[month][tag] != null) {
-                    categoryMonthlyData[month][tag] += perTagAmount;
-                }
-            });
-        });
-
-    categoryStackedChart.data.labels = months;
-
-    const categoriesWithData = stackedCategories.filter(category =>
-        months.some(month => categoryMonthlyData[month][category] > 0)
-    );
-
-    // Rebuild datasets from scratch on every update so adding/removing
-    // categories at runtime stays in sync without re-creating the chart.
-    categoryStackedChart.data.datasets = stackedCategories.map(category => {
-        const color = categoryColor(category);
-        return {
-            label: categoryLabel(category),
-            _category: category,
-            data: months.map(month => {
-                const value = categoryMonthlyData[month]?.[category] || 0;
-                return Math.round(value * 100) / 100;
-            }),
-            backgroundColor: color + 'cc',
-            borderColor: color,
-            borderWidth: 1,
-            borderRadius: 3,
-            hoverBackgroundColor: color,
-            hidden: !categoriesWithData.includes(category),
-        };
-    });
-
-    categoryStackedChart.update();
 
     // Empty-state overlays: show when a chart has no meaningful data for the
     // current filter window. Base "monthly balance" emptiness on whether any
     // income/expense activity exists — a cumulative series summing to zero
     // (e.g. matched income and expense) is still meaningful data.
     const hasIncomeExpenseData = incomeValues.some(v => v > 0) || expenseValues.some(v => v > 0);
-    const hasCategoryData = categoryValues.length > 0 && categoryValues.some(v => v > 0);
-    const hasStackedData = categoriesWithData.length > 0;
     setChartEmpty('monthlyBalance', !hasIncomeExpenseData);
     setChartEmpty('incomeVsExpense', !hasIncomeExpenseData);
     setChartEmpty('category', !hasCategoryData);
-    setChartEmpty('categoryStacked', !hasStackedData);
 }
 
 function setChartEmpty(chartName, isEmpty) {
@@ -957,8 +953,6 @@ function setChartsLoading(isLoading) {
 function setEntriesLoading(isLoading) {
     const overlay = document.getElementById('entriesTableLoadingOverlay');
     if (overlay) overlay.hidden = !isLoading;
-    const summary = document.querySelector('.entries-section .summary');
-    if (summary) summary.classList.toggle('is-loading', isLoading);
     const section = document.querySelector('.entries-section');
     if (section) section.setAttribute('aria-busy', String(!!isLoading));
 }
@@ -1046,7 +1040,6 @@ function applyFilterStateToDOM() {
     document.getElementById('monthFilterEnd').value = filterState.end || '';
     document.getElementById('typeFilter').value = filterState.type || 'all';
     renderCategoryChips();
-    syncHiddenCategorySelect();
     document.querySelectorAll('.quick-range-btn').forEach(btn => {
         const isActive = btn.dataset.range === filterState.quickRange;
         btn.classList.toggle('active', isActive);
@@ -1084,7 +1077,6 @@ function renderCategoryChips() {
             const pressed = filterState.categories.includes(cat);
             chip.classList.toggle('active', pressed);
             chip.setAttribute('aria-pressed', pressed ? 'true' : 'false');
-            syncHiddenCategorySelect();
             onFilterChanged();
         });
         container.appendChild(chip);
@@ -1127,36 +1119,6 @@ function hexWithAlpha(hex, alpha) {
     const g = parseInt(h.slice(2, 4), 16);
     const b = parseInt(h.slice(4, 6), 16);
     return `rgba(${r},${g},${b},${alpha})`;
-}
-
-function syncHiddenCategorySelect() {
-    const select = document.getElementById('categoryFilter');
-    if (!select) return;
-    // Rebuild option list from runtime user categories so the hidden
-    // <select> stays in sync as categories are added/removed.
-    const desired = userCategories.map(c => c.slug);
-    const existing = Array.from(select.options).map(o => o.value);
-    const slugListChanged = desired.length !== existing.length || desired.some((s, i) => s !== existing[i]);
-    if (slugListChanged) {
-        select.innerHTML = '';
-        userCategories.forEach(c => {
-            const opt = document.createElement('option');
-            opt.value = c.slug;
-            opt.textContent = categoryLabel(c.slug);
-            select.appendChild(opt);
-        });
-    } else {
-        // Slug list unchanged — but labels can still drift (rename, language
-        // switch affecting default labels, imported badge changes). Refresh
-        // each option's textContent so the hidden select stays consistent.
-        Array.from(select.options).forEach(opt => {
-            const fresh = categoryLabel(opt.value);
-            if (opt.textContent !== fresh) opt.textContent = fresh;
-        });
-    }
-    Array.from(select.options).forEach(opt => {
-        opt.selected = filterState.categories.includes(opt.value);
-    });
 }
 
 function readFilterStateFromInputs() {
@@ -1248,7 +1210,7 @@ function renderActiveFiltersBar() {
     filterState.categories.forEach(cat => {
         chips.push({ label: categoryLabel(cat), onRemove: () => {
             filterState.categories = filterState.categories.filter(c => c !== cat);
-            renderCategoryChips(); syncHiddenCategorySelect(); saveFilterState(); renderActiveFiltersBar(); filterEntries();
+            renderCategoryChips(); saveFilterState(); renderActiveFiltersBar(); filterEntries();
         }});
     });
 
@@ -1421,13 +1383,11 @@ function displayEntries(entriesToShow) {
     pageEntries.forEach(entry => {
         const row = document.createElement('tr');
         const escapedDescription = escapeHtml(entry.description);
+        // Theme-neutral chip; the user's stored category color renders as a
+        // small dot (--tag-dot-color) instead of tinting the whole chip, so
+        // chips stay readable in both themes regardless of the stored hex.
         const tags = (entry.tags || []).map(tag =>
-            (() => {
-                const _col = categoryColor(tag);
-                const _bg = hexWithAlpha(_col, 0.15);
-                const _bd = hexWithAlpha(_col, 0.3);
-                return `<span class="tag tag-${escapeHtml(tag)}" style="background:${_bg};color:${_col};border-color:${_bd}">${escapeHtml(categoryLabel(tag))}</span>`;
-            })()
+            `<span class="tag" style="--tag-dot-color:${escapeHtml(categoryColor(tag))}">${escapeHtml(categoryLabel(tag))}</span>`
         ).join(' ');
         const coupleBadge = entry.isCoupleExpense ? `<span class="couple-badge">${t('dash.couple')}</span>` : '';
         const inMyShare = currentViewMode === 'myshare';
@@ -1456,7 +1416,7 @@ function displayEntries(entriesToShow) {
             <td><span class="entry-type entry-type-${escapeHtml(entry.type)}">${escapeHtml(entry.type)}</span></td>
             <td>$${parseFloat(entry.amount).toFixed(2)}</td>
             <td>${halfBadge}${coupleBadge}${escapedDescription}</td>
-            <td>${tags || '<span class="tag tag-other">-</span>'}</td>
+            <td>${tags || '<span class="tag">-</span>'}</td>
             <td>${actionButtons}</td>
         `;
         tbody.appendChild(row);
@@ -1497,7 +1457,8 @@ function renderEntriesPagination(totalEntries, totalPages) {
     `;
 }
 
-// Update summary statistics
+// Update summary statistics (hero net-worth + KPI row; the old 3-stat
+// summary bar above the entries table was removed — it duplicated the hero).
 function updateSummary(entriesToShow) {
     const totalIncome = entriesToShow
         .filter(entry => entry.type === 'income')
@@ -1509,24 +1470,6 @@ function updateSummary(entriesToShow) {
 
     const netBalance = totalIncome - totalExpenses;
 
-    const incomeEl = document.getElementById('totalIncome');
-    const expensesEl = document.getElementById('totalExpenses');
-    const netEl = document.getElementById('netBalance');
-
-    if (incomeEl) {
-        incomeEl.textContent = `$${totalIncome.toFixed(2)}`;
-        incomeEl.style.color = 'var(--positive)';
-    }
-    if (expensesEl) {
-        expensesEl.textContent = `$${totalExpenses.toFixed(2)}`;
-        expensesEl.style.color = 'var(--negative)';
-    }
-    if (netEl) {
-        netEl.textContent = `$${netBalance.toFixed(2)}`;
-        netEl.style.color = netBalance >= 0 ? 'var(--ink)' : 'var(--negative)';
-    }
-
-    // Hero / KPI row
     updateHeroKpis(entriesToShow, { totalIncome, totalExpenses, netBalance });
 }
 
@@ -1688,11 +1631,11 @@ function updateHeroKpis(entriesToShow, totals) {
         const sparkEl = document.getElementById(idSpark);
         if (sparkEl) sparkEl.innerHTML = renderSparkline(series, opts.color);
     };
-    setKpi('kpiIncomeValue', 'kpiIncomeDelta', 'kpiIncomeSpark', latestM.income, prevM.income, incomeSeries, { color: 'var(--accent-1)' });
-    setKpi('kpiExpenseValue', 'kpiExpenseDelta', 'kpiExpenseSpark', latestM.expense, prevM.expense, expenseSeries, { color: 'var(--primary)', invert: true });
+    setKpi('kpiIncomeValue', 'kpiIncomeDelta', 'kpiIncomeSpark', latestM.income, prevM.income, incomeSeries, { color: 'var(--positive)' });
+    setKpi('kpiExpenseValue', 'kpiExpenseDelta', 'kpiExpenseSpark', latestM.expense, prevM.expense, expenseSeries, { color: 'var(--negative)', invert: true });
     const latestRate = latestM.income > 0 ? ((latestM.income - latestM.expense) / latestM.income) * 100 : 0;
     const prevRate = prevM.income > 0 ? ((prevM.income - prevM.expense) / prevM.income) * 100 : 0;
-    setKpi('kpiSavingValue', 'kpiSavingDelta', 'kpiSavingSpark', latestRate, prevRate, savingSeries, { color: 'var(--accent-2)', percent: true });
+    setKpi('kpiSavingValue', 'kpiSavingDelta', 'kpiSavingSpark', latestRate, prevRate, savingSeries, { color: 'var(--primary)', percent: true });
 }
 
 // Pure-SVG sparkline. Mirrors the shape used by the design prototype
@@ -1937,7 +1880,6 @@ function renderCategoryManageList() {
                     await loadUserCategories();
                     renderCategoryManageList();
                     renderCategoryChips();
-                    syncHiddenCategorySelect();
                     filterEntries({ resetPage: false });
                 }
             } catch (e) { console.error(e); }
@@ -1970,7 +1912,6 @@ function renderCategoryManageList() {
                         await loadUserCategories();
                         renderCategoryManageList();
                         renderCategoryChips();
-                        syncHiddenCategorySelect();
                         filterEntries({ resetPage: false });
                     }
                 } catch (e) { console.error(e); }
@@ -2007,7 +1948,6 @@ function renderCategoryManageList() {
                     await loadUserCategories();
                     renderCategoryManageList();
                     renderCategoryChips();
-                    syncHiddenCategorySelect();
                     filterEntries({ resetPage: false });
                 }
             } catch (e) { console.error(e); }
@@ -2110,7 +2050,6 @@ if (addCategoryBtn) {
             await loadUserCategories();
             renderCategoryManageList();
             renderCategoryChips();
-            syncHiddenCategorySelect();
             filterEntries({ resetPage: false });
             newCategorySlugInput.value = '';
             newCategoryLabelInput.value = '';
@@ -2130,7 +2069,6 @@ if (resetCategoriesBtn) {
                 await loadUserCategories();
                 renderCategoryManageList();
                 renderCategoryChips();
-                syncHiddenCategorySelect();
                 filterEntries({ resetPage: false });
             } else if (res.status === 409) {
                 // Restoring would push the user past the cap (deleted defaults
@@ -3222,7 +3160,7 @@ document.addEventListener('DOMContentLoaded', () => {
         else if (mq.addListener) mq.addListener(handleBreakpoint);
     }
 
-    // Category chart type toggle (bar ↔ doughnut)
+    // Categories chart type toggle (bar / doughnut / stacked)
     document.querySelectorAll('.chart-type-toggle .chart-type-btn').forEach(btn => {
         // Sync initial aria-pressed from the pre-set .active class in HTML.
         btn.setAttribute('aria-pressed', String(btn.classList.contains('active')));
@@ -3399,6 +3337,34 @@ document.addEventListener('DOMContentLoaded', () => {
         return res.json();
     }
 
+    // Shared by the Budgets modal and the dashboard budget panel.
+    // Safe progress: null pct when no target. Cap at 100% for the bar fill
+    // but keep the raw ratio so callers can surface an "over budget" pill.
+    const budgetProgressFor = (amount, actual) => {
+        if (!amount || amount <= 0) return { pct: null, over: false };
+        const ratio = actual / amount;
+        return { pct: Math.min(ratio, 1) * 100, over: ratio > 1, raw: ratio * 100 };
+    };
+    const budgetBarColor = (p) => {
+        if (!p || p.pct == null) return 'var(--ink-3)';
+        if (p.over) return 'var(--negative)';
+        if (p.pct >= 70) return 'var(--warning)';
+        return 'var(--positive)';
+    };
+    // Locale-aware currency formatter (pt-BR → BRL/R$, en-US → USD/$).
+    // Matches the hero-KPI formatting introduced in PR #91; we don't honor
+    // `data.currency` from the API because the server intentionally doesn't
+    // dictate it (currency follows the client's language).
+    const budgetMoneyFmt = () => {
+        const isPt = (typeof getLang === 'function' && getLang() === 'pt');
+        return new Intl.NumberFormat(isPt ? 'pt-BR' : 'en-US', {
+            style: 'currency',
+            currency: isPt ? 'BRL' : 'USD',
+            minimumFractionDigits: 2,
+            maximumFractionDigits: 2
+        });
+    };
+
     async function openBudgetsModal() {
         const overlay = document.createElement('div');
         overlay.className = 'modal';
@@ -3414,7 +3380,12 @@ document.addEventListener('DOMContentLoaded', () => {
             </div>
         `;
         document.body.appendChild(overlay);
-        const cleanup = () => { if (overlay.parentNode) overlay.parentNode.removeChild(overlay); };
+        const cleanup = () => {
+            if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+            // Targets may have changed while the modal was open — sync the
+            // dashboard budget panel.
+            refreshBudgetPanel();
+        };
         overlay.querySelector('#closeBudgetsModal').addEventListener('click', cleanup);
         overlay.addEventListener('click', (e) => { if (e.target === overlay) cleanup(); });
 
@@ -3436,31 +3407,10 @@ document.addEventListener('DOMContentLoaded', () => {
         const overall = data.overall || { amount: 0, actual: 0 };
         const rows = data.byCategory || [];
 
-        // Locale-aware currency formatter (pt-BR → BRL/R$, en-US → USD/$).
-        // Matches the hero-KPI formatting introduced in PR #91; we don't
-        // honor `data.currency` from the API because the server intentionally
-        // doesn't dictate it (currency follows the client's language).
-        const isPt = (typeof getLang === 'function' && getLang() === 'pt');
-        const moneyFmt = new Intl.NumberFormat(isPt ? 'pt-BR' : 'en-US', {
-            style: 'currency',
-            currency: isPt ? 'BRL' : 'USD',
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2
-        });
+        const moneyFmt = budgetMoneyFmt();
         const fmtMoney = (n) => moneyFmt.format(Number(n) || 0);
-        // Safe progress: 0 if no budget. Cap at 100% for the bar fill but
-        // surface a separate "over budget" pill when actual > budget.
-        const progressFor = (amount, actual) => {
-            if (!amount || amount <= 0) return { pct: null, over: false };
-            const ratio = actual / amount;
-            return { pct: Math.min(ratio, 1) * 100, over: ratio > 1, raw: ratio * 100 };
-        };
-        const barColor = (p) => {
-            if (!p) return 'var(--ink-3)';
-            if (p.over) return 'var(--negative)';
-            if (p.pct >= 70) return 'var(--accent-2)';
-            return 'var(--positive)';
-        };
+        const progressFor = budgetProgressFor;
+        const barColor = budgetBarColor;
 
         const renderRow = (slug, label, color, amount, actual, isOverall, isOrphan) => {
             const p = progressFor(amount, actual);
@@ -3635,6 +3585,77 @@ document.addEventListener('DOMContentLoaded', () => {
             });
         });
     }
+
+    // ── Budget status panel (dashboard) ──
+    // Read-only mirror of the Budgets modal for the current calendar month:
+    // the overall budget plus the top budgeted categories by spend. It is
+    // intentionally independent of the dashboard filters (the wrapper's
+    // tooltip says so); "Manage budgets" opens the full modal.
+    async function refreshBudgetPanel() {
+        const body = document.getElementById('budgetStatusBody');
+        if (!body) return;
+        const month = currentClientMonth();
+        const monthEl = document.getElementById('budgetPanelMonth');
+        if (monthEl) monthEl.textContent = month;
+        setSingleChartLoading('budget', true);
+        try {
+            const data = await loadBudgets(month);
+            renderBudgetPanel(body, data);
+        } catch (e) {
+            console.error('Failed to load the budget panel:', e);
+            body.innerHTML = `<div class="budget-panel-empty">${escapeHtml(t('budget.loadError'))}</div>`;
+        } finally {
+            setSingleChartLoading('budget', false);
+        }
+    }
+
+    function renderBudgetPanel(container, data) {
+        const overall = data.overall || { amount: 0, actual: 0 };
+        const budgeted = (data.byCategory || []).filter(r => Number(r.amount) > 0);
+        const hasOverall = Number(overall.amount) > 0;
+        if (!hasOverall && budgeted.length === 0) {
+            container.innerHTML = `<div class="budget-panel-empty">${escapeHtml(t('budget.emptyPanel'))}</div>`;
+            return;
+        }
+        const moneyFmt = budgetMoneyFmt();
+        const fmtMoney = (n) => moneyFmt.format(Number(n) || 0);
+        const rowHtml = (label, color, amount, actual, isOverall) => {
+            const p = budgetProgressFor(Number(amount), Number(actual));
+            const width = p.pct == null ? 0 : p.pct;
+            const fill = budgetBarColor(p);
+            const overPill = p.over ? ` <span class="delta-pill down">${escapeHtml(t('budget.overBudget'))}</span>` : '';
+            const pct = p.pct == null ? '' : ' · ' + (p.over ? p.raw : p.pct).toFixed(0) + '%';
+            const dot = isOverall ? '' : '<i class="budget-dot" aria-hidden="true"></i>';
+            const dotColor = color ? ` style="--budget-dot-color: ${escapeHtml(color)}"` : '';
+            return `
+                <div class="budget-row${isOverall ? ' budget-row--overall' : ''}">
+                    <div class="budget-row-top">
+                        <span class="budget-row-name"${dotColor}>${dot}<span>${escapeHtml(label)}</span>${overPill}</span>
+                        <span class="budget-row-nums">${fmtMoney(actual)} / ${fmtMoney(amount)}${pct}</span>
+                    </div>
+                    <div class="budget-row-track"><div class="budget-row-fill" style="width: ${width}%; background: ${fill};"></div></div>
+                </div>`;
+        };
+        // Same slug → localized-label resolution as the Budgets modal.
+        const panelRowLabel = (r) => {
+            if (!r || !r.slug) return (r && r.label) || '';
+            if (typeof categoryLabel !== 'function') return r.label || r.slug;
+            const localized = categoryLabel(r.slug);
+            return localized && localized !== r.slug ? localized : (r.label || r.slug);
+        };
+        // Fullest budgets surface first; cap the list so the panel stays
+        // scannable (the modal has the complete set).
+        budgeted.sort((a, b) => Number(b.actual) - Number(a.actual));
+        const parts = [];
+        if (hasOverall) parts.push(rowHtml(t('budget.overallLabel'), null, overall.amount, overall.actual, true));
+        budgeted.slice(0, 6).forEach(r => {
+            parts.push(rowHtml(panelRowLabel(r), r.color, r.amount, r.actual, false));
+        });
+        container.innerHTML = parts.join('');
+    }
+
+    const budgetPanelManageBtn = document.getElementById('budgetPanelManageBtn');
+    if (budgetPanelManageBtn) budgetPanelManageBtn.addEventListener('click', openBudgetsModal);
 
     // ============ SETTINGS MODAL ============
 
@@ -5145,7 +5166,6 @@ document.addEventListener('DOMContentLoaded', () => {
                         if (seq !== loadEntriesSeq) return;
                         if (currentViewMode === 'individual') return;
                         renderCategoryChips();
-                        syncHiddenCategorySelect();
                         // Re-apply filters/charts with the freshly known palette.
                         filterEntries({ resetPage: false });
                     });
@@ -5626,14 +5646,17 @@ document.addEventListener('DOMContentLoaded', () => {
         myShareBtn.addEventListener('click', () => setViewMode('myshare'));
     }
 
-    // Restore saved category chart type
+    // Restore saved category chart type ('bar' is the built-in default)
     try {
         const savedType = localStorage.getItem('assetmgmt.categoryChartType');
-        if (savedType === 'doughnut') {
-            const doughBtn = document.querySelector('.chart-type-toggle .chart-type-btn[data-type="doughnut"]');
-            if (doughBtn) doughBtn.click();
+        if (savedType === 'doughnut' || savedType === 'stacked') {
+            const savedBtn = document.querySelector(`.chart-type-toggle .chart-type-btn[data-type="${savedType}"]`);
+            if (savedBtn) savedBtn.click();
         }
     } catch {}
+
+    // Initial fill of the dashboard budget panel (current calendar month)
+    refreshBudgetPanel();
 
     // Fetch current user on load
     fetchCurrentUser();

--- a/js/app.js
+++ b/js/app.js
@@ -5063,6 +5063,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 // the correct palette + labels. Self-heals via the GET
                 // endpoint if the user has no rows yet.
                 await loadUserCategories();
+                // Initial fill of the dashboard budget panel — deliberately
+                // after the categories load so panelRowLabel resolves
+                // localized labels instead of raw server slugs (and after
+                // auth is confirmed, so we don't fetch budgets for a session
+                // that's about to be redirected to login).
+                refreshBudgetPanel();
                 // Now that we know the user id, reload filters under their
                 // key (they were loaded under 'anon' at DOMContentLoaded).
                 // Always reset — falling back to defaults when the user has
@@ -5712,9 +5718,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     } catch {}
 
-    // Initial fill of the dashboard budget panel (current calendar month)
-    refreshBudgetPanel();
-
-    // Fetch current user on load
+    // Fetch current user on load (also triggers the initial budget-panel
+    // fill once categories are known — see fetchCurrentUser)
     fetchCurrentUser();
 });

--- a/js/app.js
+++ b/js/app.js
@@ -123,6 +123,9 @@ function buildCategoryChart(ctx, type, colors) {
     };
     const title = {
         display: true,
+        // Left-aligned so the centered default doesn't collide with the
+        // absolutely-positioned Bar/Doughnut/Trend toggle in the top-right.
+        align: 'start',
         text: type === 'stacked' ? t('chart.expenseCatByMonth') : t('chart.expensesByCategory'),
         color: colors.textPrimary,
         font: { size: 14, weight: '600', family: _chartSerifFamily() },

--- a/js/app.js
+++ b/js/app.js
@@ -1740,7 +1740,7 @@ function updateCoupleShare(entriesToShow) {
 
         settlementEl.textContent = `$${owedAmount.toFixed(2)}`;
         settlementEl.className = 'settlement-amount';
-        settlementEl.style.color = '#f59e0b';
+        settlementEl.style.color = 'var(--warning)';
         directionEl.textContent = t('dash.owes', { underpayer: underpayer, overpayer: overpayer });
     }
 }
@@ -2995,6 +2995,7 @@ document.addEventListener('DOMContentLoaded', () => {
             lastFocused = document.activeElement;
             sidebar.classList.add('open');
             backdrop.classList.add('open');
+            document.body.classList.add('drawer-open');
             toggle.setAttribute('aria-expanded', 'true');
             setToggleLabel(true);
             // Move focus into the drawer so SR users land on the nav.
@@ -3005,6 +3006,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const wasOpen = sidebar.classList.contains('open');
             sidebar.classList.remove('open');
             backdrop.classList.remove('open');
+            document.body.classList.remove('drawer-open');
             toggle.setAttribute('aria-expanded', 'false');
             setToggleLabel(false);
             // Restore focus to whichever element opened the drawer (the

--- a/js/chat.js
+++ b/js/chat.js
@@ -29,6 +29,7 @@
     function openChat() {
         chatOpen = true;
         win.classList.add('open');
+        if (fab) fab.setAttribute('aria-expanded', 'true');
         input.focus();
 
         if (!welcomeSent) {
@@ -41,6 +42,7 @@
     function closeChat() {
         chatOpen = false;
         win.classList.remove('open');
+        if (fab) fab.setAttribute('aria-expanded', 'false');
     }
 
     function appendMessage(role, content) {

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -154,6 +154,9 @@ const translations = {
     'kpi.expenseHelp': 'Total expenses recorded in the latest month in view. The percentage is the month-over-month change vs the previous month.',
     'kpi.savingRateHelp': '(Income − Expenses) ÷ Income × 100 for the latest month. The "pts" value is the point change vs the previous month, not a percent of a percent.',
 
+    // ── Accessibility ──
+    'a11y.skipToContent': 'Skip to content',
+
     // ── Reports (issue #92) ──
     'report.title': 'Export report',
     'report.help': 'Download a CSV or PDF of your entries. The report respects your current view mode and category filter.',
@@ -488,24 +491,12 @@ const translations = {
     // ── Login page ──
     'login.title': 'Asset Manager',
     'login.heroTagline': 'Take control of your finances with a secure, intelligent platform built for individuals and couples who want real visibility into their money.',
-    'login.feature.encryption': 'AES-256 Encryption',
-    'login.feature.encryptionDesc': 'Your data encrypted at rest with bank-grade security',
-    'login.feature.analytics': 'Visual Analytics',
-    'login.feature.analyticsDesc': 'Interactive charts for income, expenses, and categories',
     'login.feature.ai': 'AI-Powered Import',
     'login.feature.aiDesc': 'Upload bank statements and let AI extract transactions',
     'login.feature.couples': 'Couples Mode',
     'login.feature.couplesDesc': 'Link accounts with your partner for shared tracking',
-    'login.feature.mobile': 'Mobile Native',
-    'login.feature.mobileDesc': 'Full iOS app for managing finances on the go',
-    'login.feature.categories': 'Smart Categories',
-    'login.feature.categoriesDesc': '17 built-in tags for granular categorization',
-    'login.feature.twoFactor': 'Two-Factor Auth (2FA)',
-    'login.feature.twoFactorDesc': 'Protect your account with TOTP authenticator apps and backup codes',
     'login.feature.aiChat': 'AI Financial Advisor',
     'login.feature.aiChatDesc': 'Chat with an AI advisor that analyzes your real financial data',
-    'login.feature.reports': 'Reports & Export',
-    'login.feature.reportsDesc': 'Download CSV or PDF reports of your filtered entries with summary, category breakdown, and totals',
     'login.feature.budgets': 'Monthly Budgets',
     'login.feature.budgetsDesc': 'Set per-category monthly targets and track real-time progress against an overall ceiling',
     'login.welcome': 'Welcome Back',
@@ -801,6 +792,9 @@ const translations = {
     'kpi.incomeHelp': 'Receita registrada no \u00faltimo m\u00eas do per\u00edodo. A porcentagem \u00e9 a varia\u00e7\u00e3o m\u00eas-a-m\u00eas em rela\u00e7\u00e3o ao m\u00eas anterior.',
     'kpi.expenseHelp': 'Despesas registradas no \u00faltimo m\u00eas do per\u00edodo. A porcentagem \u00e9 a varia\u00e7\u00e3o m\u00eas-a-m\u00eas em rela\u00e7\u00e3o ao m\u00eas anterior.',
     'kpi.savingRateHelp': '(Receita \u2212 Despesas) \u00f7 Receita \u00d7 100 para o \u00faltimo m\u00eas. O valor em "pts" \u00e9 a varia\u00e7\u00e3o em pontos vs o m\u00eas anterior, n\u00e3o uma porcentagem de uma porcentagem.',
+
+    // \u2500\u2500 Accessibility \u2500\u2500
+    'a11y.skipToContent': 'Pular para o conte\u00fado',
 
     // \u2500\u2500 Reports (issue #92) \u2500\u2500
     'report.title': 'Exportar relat\u00f3rio',
@@ -1136,24 +1130,12 @@ const translations = {
     // ── Login page ──
     'login.title': 'Asset Manager',
     'login.heroTagline': 'Assuma o controle das suas finan\u00e7as com uma plataforma segura e inteligente, feita para pessoas e casais que querem ter visibilidade real sobre seu dinheiro.',
-    'login.feature.encryption': 'Criptografia AES-256',
-    'login.feature.encryptionDesc': 'Seus dados criptografados em repouso com seguran\u00e7a banc\u00e1ria',
-    'login.feature.analytics': 'An\u00e1lise Visual',
-    'login.feature.analyticsDesc': 'Gr\u00e1ficos interativos para receitas, despesas e categorias',
     'login.feature.ai': 'Importa\u00e7\u00e3o com IA',
     'login.feature.aiDesc': 'Envie extratos banc\u00e1rios e deixe a IA extrair as transa\u00e7\u00f5es',
     'login.feature.couples': 'Modo Casal',
     'login.feature.couplesDesc': 'Vincule contas com seu parceiro(a) para acompanhamento compartilhado',
-    'login.feature.mobile': 'App Nativo',
-    'login.feature.mobileDesc': 'App iOS completo para gerenciar finan\u00e7as em qualquer lugar',
-    'login.feature.categories': 'Categorias Inteligentes',
-    'login.feature.categoriesDesc': '17 tags integradas para categorização detalhada',
-    'login.feature.twoFactor': 'Autenticação em Dois Fatores (2FA)',
-    'login.feature.twoFactorDesc': 'Proteja sua conta com apps autenticadores TOTP e códigos de backup',
     'login.feature.aiChat': 'Consultor Financeiro IA',
     'login.feature.aiChatDesc': 'Converse com um consultor IA que analisa seus dados financeiros reais',
-    'login.feature.reports': 'Relatórios & Exportação',
-    'login.feature.reportsDesc': 'Baixe relatórios em CSV ou PDF dos seus lançamentos filtrados com resumo, divisão por categoria e totais',
     'login.feature.budgets': 'Orçamentos Mensais',
     'login.feature.budgetsDesc': 'Defina metas mensais por categoria e acompanhe o progresso em tempo real contra um teto geral',
     'login.welcome': 'Bem-vindo de Volta',

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -416,12 +416,10 @@ const translations = {
     // ── Appearance settings ──
     'settings.appearanceSection': 'Appearance',
     'settings.themeLabel': 'Theme',
-    'settings.themeEarthy': 'Earthy (default)',
-    'settings.themeDark': 'Dark',
-    'settings.themeLight': 'Light',
+    'settings.themePaper': 'Paper — light (default)',
+    'settings.themeDark': 'Graphite — dark',
     'settings.typographyLabel': 'Typography',
-    'settings.typographyEditorial': 'Editorial (default)',
-    'settings.typographyModern': 'Modern',
+    'settings.typographyDefault': 'Ledger (default)',
     'settings.typographySystem': 'System',
     'settings.appearanceHelp': 'Saved on this device. Charts and the auth pages adopt the same look.',
 
@@ -1069,12 +1067,10 @@ const translations = {
     // ── Appearance settings ──
     'settings.appearanceSection': 'Aparência',
     'settings.themeLabel': 'Tema',
-    'settings.themeEarthy': 'Terroso (padrão)',
-    'settings.themeDark': 'Escuro',
-    'settings.themeLight': 'Claro',
+    'settings.themePaper': 'Paper — claro (padrão)',
+    'settings.themeDark': 'Graphite — escuro',
     'settings.typographyLabel': 'Tipografia',
-    'settings.typographyEditorial': 'Editorial (padrão)',
-    'settings.typographyModern': 'Moderna',
+    'settings.typographyDefault': 'Ledger (padrão)',
     'settings.typographySystem': 'Sistema',
     'settings.appearanceHelp': 'Salvo neste dispositivo. Gráficos e páginas de autenticação seguem o mesmo estilo.',
 

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -121,6 +121,7 @@ const translations = {
     'filter.chartType': 'Chart type',
     'filter.chartBar': 'Bar',
     'filter.chartDoughnut': 'Doughnut',
+    'filter.chartStacked': 'Trend',
     'chart.noData': 'No data for current filters',
 
     // ── Couple share ──
@@ -178,6 +179,10 @@ const translations = {
     'budget.deleteError': 'Failed to delete budget.',
     'budget.invalidAmount': 'Please enter a non-negative number.',
     'budget.orphanLabel': '(removed)',
+    'dash.budgetStatus': 'Budget status',
+    'budget.manageLink': 'Manage budgets',
+    'budget.emptyPanel': 'No budgets set. Add monthly targets to see progress here.',
+    'budget.panelHelp': 'Current calendar month, your budgets only — filters don\'t apply.',
 
     // ── Entries table ──
     'dash.registeredEntries': 'Registered Entries',
@@ -764,6 +769,7 @@ const translations = {
     'filter.chartType': 'Tipo de gr\u00e1fico',
     'filter.chartBar': 'Barra',
     'filter.chartDoughnut': 'Rosca',
+    'filter.chartStacked': 'Tend\u00eancia',
     'chart.noData': 'Sem dados para os filtros atuais',
 
     // ── Couple share ──
@@ -821,6 +827,10 @@ const translations = {
     'budget.deleteError': 'Falha ao remover or\u00e7amento.',
     'budget.invalidAmount': 'Informe um n\u00famero n\u00e3o-negativo.',
     'budget.orphanLabel': '(removida)',
+    'dash.budgetStatus': 'Or\u00e7amentos do m\u00eas',
+    'budget.manageLink': 'Gerenciar or\u00e7amentos',
+    'budget.emptyPanel': 'Nenhum or\u00e7amento definido. Adicione metas mensais para ver o progresso aqui.',
+    'budget.panelHelp': 'M\u00eas corrente, apenas seus or\u00e7amentos \u2014 os filtros n\u00e3o se aplicam.',
 
     // ── Entries table ──
     'dash.registeredEntries': 'Entradas Registradas',

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -122,6 +122,9 @@ const translations = {
     'filter.chartBar': 'Bar',
     'filter.chartDoughnut': 'Doughnut',
     'filter.chartStacked': 'Trend',
+    'filter.selectAllCats': 'All Categories',
+    'chart.avgToggle': 'Avg',
+    'chart.avgToggleHelp': 'Show or hide the average lines',
     'chart.noData': 'No data for current filters',
 
     // ── Couple share ──
@@ -761,6 +764,9 @@ const translations = {
     'filter.chartBar': 'Barra',
     'filter.chartDoughnut': 'Rosca',
     'filter.chartStacked': 'Tend\u00eancia',
+    'filter.selectAllCats': 'Todas as Categorias',
+    'chart.avgToggle': 'M\u00e9dia',
+    'chart.avgToggleHelp': 'Mostrar ou ocultar as linhas de m\u00e9dia',
     'chart.noData': 'Sem dados para os filtros atuais',
 
     // ── Couple share ──

--- a/login.html
+++ b/login.html
@@ -6,15 +6,21 @@
     <title>Login - Asset Manager</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@300;400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400..700&family=Geist:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/theme.css">
     <script>
         // Apply persisted theme + typography before stylesheets resolve. Mirrors index.html.
         (function () {
             try {
                 var t = localStorage.getItem('appTheme');
+                if (t === 'light') { t = 'paper'; try { localStorage.setItem('appTheme', 'paper'); } catch (e) {} }
+                if (t !== 'paper' && t !== 'dark') {
+                    t = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'paper';
+                }
+                if (t === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
                 var f = localStorage.getItem('appTypography');
-                if (t === 'dark' || t === 'light') document.documentElement.setAttribute('data-theme', t);
-                if (f === 'modern' || f === 'system') document.documentElement.setAttribute('data-typography', f);
+                if (f === 'modern' || f === 'editorial') { f = null; try { localStorage.removeItem('appTypography'); } catch (e) {} }
+                if (f === 'system') document.documentElement.setAttribute('data-typography', 'system');
             } catch (e) {}
         })();
     </script>
@@ -53,92 +59,7 @@
             50% { box-shadow: 0 0 100px color-mix(in oklab, var(--primary) 35%, transparent); }
         }
 
-        :root {
-            /* Warm earthy palette — Clay & Sand */
-            --bg: #F3ECE0;
-            --bg-2: #EAE0CE;
-            --card: #FBF6EC;
-            --ink: #26201A;
-            --ink-2: #5A4E3F;
-            --ink-3: #8A7A65;
-            --line: #DDD0B8;
-            --line-2: #C9B99C;
-            --primary: #B8593A;
-            --primary-soft: #E8BFAB;
-            --accent-1: #7A8450;
-            --accent-2: #C89A3E;
-            --positive: #6B8248;
-            --negative: #B8593A;
-            --chip: #E8DDC8;
-            --ring: rgba(184, 89, 58, 0.22);
-
-            --serif: "Instrument Serif", "Iowan Old Style", Georgia, serif;
-            --sans: "Geist", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-            --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-
-            /* Backwards-compatible aliases */
-            --font-display: var(--serif);
-            --font-body: var(--sans);
-
-            --color-bg-deep: var(--bg-2);
-            --color-bg-base: var(--bg);
-            --color-bg-elevated: var(--card);
-            --color-bg-surface: var(--bg-2);
-
-            --color-accent-primary: var(--primary);
-            --color-accent-secondary: var(--accent-2);
-            --color-accent-tertiary: var(--accent-1);
-
-            --color-success: var(--positive);
-            --color-danger: var(--negative);
-            --color-danger-muted: color-mix(in oklab, var(--negative) 18%, var(--card));
-
-            --color-text-primary: var(--ink);
-            --color-text-secondary: var(--ink-2);
-            --color-text-muted: var(--ink-3);
-
-            --color-border: var(--line);
-
-            --shadow-lg: 0 16px 48px rgba(38, 32, 26, 0.12);
-
-            --radius-md: 10px;
-            --radius-lg: 14px;
-            --radius-xl: 18px;
-
-            --transition-fast: 0.15s ease;
-            --transition-base: 0.25s ease;
-        }
-
-        /* Theme + typography overrides — kept in sync with index.html */
-        html[data-theme="dark"] {
-            --bg: #1A1612; --bg-2: #221C16; --card: #2A231C;
-            --ink: #F0E6D6; --ink-2: #C9B99C; --ink-3: #8A7A65;
-            --line: #3A302A; --line-2: #4A3F36;
-            --primary: #D67A5C; --primary-soft: #5A2E20;
-            --accent-1: #9CA868; --accent-2: #D9B05A;
-            --positive: #8FA866; --negative: #D67A5C;
-            --chip: #3A302A; --ring: rgba(214, 122, 92, 0.28);
-            --shadow-lg: 0 16px 48px rgba(0, 0, 0, 0.55);
-        }
-        html[data-theme="light"] {
-            --bg: #FFFFFF; --bg-2: #F5F5F5; --card: #FAFAFA;
-            --ink: #1A1A1A; --ink-2: #4A4A4A; --ink-3: #888888;
-            --line: #E5E5E5; --line-2: #D0D0D0;
-            --primary: #2563EB; --primary-soft: #BFDBFE;
-            --accent-1: #059669; --accent-2: #D97706;
-            --positive: #059669; --negative: #DC2626;
-            --chip: #F0F0F0; --ring: rgba(37, 99, 235, 0.18);
-            --shadow-lg: 0 16px 48px rgba(0, 0, 0, 0.10);
-        }
-        html[data-typography="modern"] {
-            --serif: "Inter", ui-sans-serif, system-ui, sans-serif;
-            --sans: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-        }
-        html[data-typography="system"] {
-            --serif: ui-serif, Georgia, "Iowan Old Style", serif;
-            --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-            --mono: ui-monospace, SFMono-Regular, Menlo, monospace;
-        }
+        /* Design tokens live in /css/theme.css — shared by every page. */
 
         * {
             box-sizing: border-box;

--- a/login.html
+++ b/login.html
@@ -253,7 +253,7 @@
             width: 100%;
             padding: 1.1rem;
             background: var(--primary);
-            color: #fff;
+            color: var(--on-primary);
             border: none;
             border-radius: var(--radius-md);
             font-size: 0.9rem;

--- a/login.html
+++ b/login.html
@@ -49,16 +49,6 @@
             100% { transform: rotate(360deg); }
         }
 
-        @keyframes float {
-            0%, 100% { transform: translateY(0) rotate(0deg); }
-            50% { transform: translateY(-20px) rotate(5deg); }
-        }
-
-        @keyframes pulse-glow {
-            0%, 100% { box-shadow: 0 0 60px color-mix(in oklab, var(--primary) 20%, transparent); }
-            50% { box-shadow: 0 0 100px color-mix(in oklab, var(--primary) 35%, transparent); }
-        }
-
         /* Design tokens live in /css/theme.css — shared by every page. */
 
         * {
@@ -83,45 +73,10 @@
             overflow-y: auto;
         }
 
-        /* Ambient background orbs */
-        .orb {
-            position: fixed;
-            border-radius: 50%;
-            filter: blur(90px);
-            pointer-events: none;
-            z-index: 0;
-            opacity: 0.55;
-        }
-
-        .orb-1 {
-            width: 500px;
-            height: 500px;
-            background: radial-gradient(circle, var(--primary-soft) 0%, transparent 70%);
-            top: -150px;
-            right: -100px;
-            animation: float 15s ease-in-out infinite;
-        }
-
-        .orb-2 {
-            width: 400px;
-            height: 400px;
-            background: radial-gradient(circle, color-mix(in oklab, var(--accent-1) 50%, transparent) 0%, transparent 70%);
-            bottom: -100px;
-            left: -100px;
-            animation: float 18s ease-in-out infinite reverse;
-        }
-
-        .orb-3 {
-            width: 300px;
-            height: 300px;
-            background: radial-gradient(circle, rgba(168, 85, 247, 0.08) 0%, transparent 70%);
-            top: 50%;
-            left: 50%;
-            transform: translate(-50%, -50%);
-            animation: float 12s ease-in-out infinite;
-        }
-
-        /* ── Landing Split Layout ── */
+        /* ── Landing Split Layout ──
+           The hero side sits on the same graphite chrome as the app shell's
+           sidebar/topbar, so the landing page and the dashboard read as one
+           product in both themes. */
         .landing-wrapper {
             display: flex;
             min-height: calc(100vh - env(safe-area-inset-top, 0px));
@@ -135,6 +90,7 @@
             align-items: center;
             justify-content: center;
             padding: 3rem;
+            background: var(--chrome-bg);
         }
 
         .hero-content {
@@ -143,18 +99,18 @@
         }
 
         .hero-title {
-            font-family: var(--font-display);
-            font-size: 3.5rem;
+            font-family: var(--display);
+            font-size: 3.25rem;
             font-weight: 700;
-            color: var(--color-accent-primary);
+            color: var(--chrome-ink);
             margin: 0 0 1rem 0;
-            letter-spacing: -0.03em;
+            letter-spacing: -0.02em;
             line-height: 1.1;
         }
 
         .hero-tagline {
-            color: var(--color-text-secondary);
-            font-size: 1.15rem;
+            color: var(--chrome-ink-dim);
+            font-size: 1.1rem;
             margin: 0 0 2.5rem 0;
             line-height: 1.7;
         }
@@ -166,37 +122,36 @@
         }
 
         .feature-card {
-            background: var(--color-bg-elevated);
-            border: 1px solid var(--color-border);
+            background: rgba(255, 255, 255, 0.03);
+            border: 1px solid var(--chrome-line);
             border-radius: var(--radius-md);
             padding: 1.25rem;
-            transition: all var(--transition-base);
+            transition: border-color var(--transition-base), background var(--transition-base);
         }
 
         .feature-card:hover {
-            background: var(--color-bg-deep);
-            border-color: color-mix(in oklab, var(--color-accent-primary) 30%, var(--color-bg-elevated));
-            transform: translateY(-2px);
+            background: rgba(255, 255, 255, 0.05);
+            border-color: color-mix(in oklab, var(--chrome-accent) 40%, var(--chrome-line));
         }
 
         .feature-icon {
             width: 36px;
             height: 36px;
             margin-bottom: 0.75rem;
-            color: var(--color-accent-primary);
+            color: var(--chrome-accent);
         }
 
         .feature-card h3 {
-            font-family: var(--font-body);
+            font-family: var(--sans);
             font-size: 0.9rem;
             font-weight: 600;
-            color: var(--color-text-primary);
+            color: var(--chrome-ink);
             margin: 0 0 0.35rem 0;
         }
 
         .feature-card p {
             font-size: 0.8rem;
-            color: var(--color-text-muted);
+            color: var(--chrome-ink-dim);
             margin: 0;
             line-height: 1.5;
         }
@@ -208,7 +163,7 @@
             align-items: center;
             justify-content: center;
             padding: 2rem;
-            border-left: 1px solid var(--color-border);
+            background: var(--bg);
         }
 
         .login-container {
@@ -217,25 +172,26 @@
         }
 
         .login-form {
-            background: var(--color-bg-elevated);
+            background: var(--card);
             padding: 3rem 2.5rem;
             border-radius: var(--radius-xl);
             box-shadow: var(--shadow-lg);
-            border: 1px solid var(--color-border);
+            border: 1px solid var(--line);
             text-align: center;
-            animation: fadeInUp 0.8s ease 0.15s backwards, pulse-glow 4s ease-in-out infinite;
+            animation: fadeInUp 0.8s ease 0.15s backwards;
             position: relative;
             overflow: hidden;
         }
 
+        /* Ledger tick — same motif as the dashboard section headings */
         .login-form::before {
             content: '';
             position: absolute;
             top: 0;
-            left: 0;
-            right: 0;
-            height: 4px;
-            background: linear-gradient(90deg, var(--color-accent-primary) 0%, var(--color-accent-secondary) 50%, var(--color-accent-tertiary) 100%);
+            left: 2.5rem;
+            width: 24px;
+            height: 2px;
+            background: var(--primary);
         }
 
         .login-form h2 {
@@ -294,27 +250,25 @@
         button {
             width: 100%;
             padding: 1.1rem;
-            background: linear-gradient(135deg, var(--color-accent-primary) 0%, var(--color-accent-tertiary) 100%);
-            color: var(--color-bg-deep);
+            background: var(--primary);
+            color: #fff;
             border: none;
             border-radius: var(--radius-md);
             font-size: 0.9rem;
-            font-family: var(--font-body);
-            font-weight: 700;
+            font-family: var(--sans);
+            font-weight: 600;
             cursor: pointer;
-            transition: all var(--transition-base);
+            transition: background var(--transition-base), box-shadow var(--transition-base), transform var(--transition-base);
             margin-top: 0.5rem;
-            text-transform: uppercase;
-            letter-spacing: 0.08em;
-            box-shadow: 0 4px 24px color-mix(in oklab, var(--primary) 30%, transparent);
+            letter-spacing: 0.02em;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
         }
 
         button:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 8px 32px color-mix(in oklab, var(--primary) 40%, transparent);
+            background: color-mix(in oklab, var(--primary) 88%, black);
+            box-shadow: 0 4px 16px var(--ring);
         }
 
         button:active {
@@ -325,7 +279,7 @@
             margin-top: 1.5rem;
             padding: 1rem 1.25rem;
             background: var(--color-danger-muted);
-            border: 1px solid rgba(239, 68, 68, 0.3);
+            border: 1px solid color-mix(in oklab, var(--negative) 35%, var(--card));
             border-radius: var(--radius-md);
             color: var(--color-danger);
             font-size: 0.875rem;
@@ -356,8 +310,8 @@
             left: 50%;
             margin-top: -10px;
             margin-left: -10px;
-            border: 2.5px solid rgba(255, 255, 255, 0.3);
-            border-top: 2.5px solid var(--color-text-primary);
+            border: 2.5px solid rgba(255, 255, 255, 0.35);
+            border-top: 2.5px solid #fff;
             border-radius: 50%;
             animation: spin 0.6s linear infinite;
         }
@@ -461,11 +415,7 @@
             .login-form button {
                 font-size: 0.8rem;
                 padding: 0.9rem;
-                letter-spacing: 0.04em;
-            }
-
-            .orb-1, .orb-2 {
-                opacity: 0.5;
+                letter-spacing: 0.02em;
             }
         }
 
@@ -501,9 +451,6 @@
 </head>
 <body>
     <button class="lang-toggle" data-i18n-title="lang.switch.title" onclick="setLang(getLang()==='en'?'pt':'en')" aria-label="Toggle language">🌐</button>
-    <div class="orb orb-1"></div>
-    <div class="orb orb-2"></div>
-    <div class="orb orb-3"></div>
 
     <div class="landing-wrapper">
         <!-- Hero / Features Side -->
@@ -513,26 +460,6 @@
                 <p class="hero-tagline" data-i18n="login.heroTagline">Take control of your finances with a secure, intelligent platform built for individuals and couples who want real visibility into their money.</p>
 
                 <div class="feature-grid">
-                    <div class="feature-card">
-                        <svg class="feature-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                            <path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/>
-                            <path d="M9 12l2 2 4-4"/>
-                        </svg>
-                        <h3 data-i18n="login.feature.encryption">AES-256 Encryption</h3>
-                        <p data-i18n="login.feature.encryptionDesc">Your data encrypted at rest with bank-grade security</p>
-                    </div>
-
-                    <div class="feature-card">
-                        <svg class="feature-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                            <rect x="3" y="3" width="18" height="18" rx="2"/>
-                            <path d="M7 17v-4"/>
-                            <path d="M12 17v-8"/>
-                            <path d="M17 17v-6"/>
-                        </svg>
-                        <h3 data-i18n="login.feature.analytics">Visual Analytics</h3>
-                        <p data-i18n="login.feature.analyticsDesc">Interactive charts for income, expenses, and categories</p>
-                    </div>
-
                     <div class="feature-card">
                         <svg class="feature-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                             <path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/>
@@ -559,51 +486,11 @@
 
                     <div class="feature-card">
                         <svg class="feature-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                            <rect x="5" y="2" width="14" height="20" rx="2" ry="2"/>
-                            <path d="M12 18h.01"/>
-                        </svg>
-                        <h3 data-i18n="login.feature.mobile">Mobile Native</h3>
-                        <p data-i18n="login.feature.mobileDesc">Full iOS app for managing finances on the go</p>
-                    </div>
-
-                    <div class="feature-card">
-                        <svg class="feature-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                            <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/>
-                            <line x1="7" y1="7" x2="7.01" y2="7"/>
-                        </svg>
-                        <h3 data-i18n="login.feature.categories">Smart Categories</h3>
-                        <p data-i18n="login.feature.categoriesDesc">17 built-in tags for granular categorization</p>
-                    </div>
-
-                    <div class="feature-card">
-                        <svg class="feature-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                            <rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>
-                            <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
-                            <circle cx="12" cy="16" r="1"/>
-                        </svg>
-                        <h3 data-i18n="login.feature.twoFactor">Two-Factor Auth (2FA)</h3>
-                        <p data-i18n="login.feature.twoFactorDesc">Protect your account with TOTP authenticator apps and backup codes</p>
-                    </div>
-
-                    <div class="feature-card">
-                        <svg class="feature-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                             <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/>
                             <path d="M8 10h.01"/><path d="M12 10h.01"/><path d="M16 10h.01"/>
                         </svg>
                         <h3 data-i18n="login.feature.aiChat">AI Financial Advisor</h3>
                         <p data-i18n="login.feature.aiChatDesc">Chat with an AI advisor that analyzes your real financial data</p>
-                    </div>
-
-                    <div class="feature-card">
-                        <svg class="feature-icon" aria-hidden="true" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
-                            <polyline points="14 2 14 8 20 8"/>
-                            <line x1="8" y1="13" x2="16" y2="13"/>
-                            <line x1="8" y1="17" x2="16" y2="17"/>
-                            <polyline points="10 9 9 9 8 9"/>
-                        </svg>
-                        <h3 data-i18n="login.feature.reports">Reports &amp; Export</h3>
-                        <p data-i18n="login.feature.reportsDesc">Download CSV or PDF reports of your filtered entries with summary, category breakdown, and totals</p>
                     </div>
 
                     <div class="feature-card">

--- a/login.html
+++ b/login.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Login - Asset Manager</title>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='44' fill='%230F6B4F'/%3E%3Crect x='30' y='46' width='40' height='8' rx='2' fill='%23fff'/%3E%3C/svg%3E">
+    <meta name="theme-color" content="#F6F6F4">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400..700&family=Geist:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">

--- a/register.html
+++ b/register.html
@@ -6,15 +6,21 @@
     <title>Register - Asset Manager</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Geist:wght@300;400;500;600;700&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400..700&family=Geist:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/css/theme.css">
     <script>
         // Apply persisted theme + typography before stylesheets resolve. Mirrors index.html.
         (function () {
             try {
                 var t = localStorage.getItem('appTheme');
+                if (t === 'light') { t = 'paper'; try { localStorage.setItem('appTheme', 'paper'); } catch (e) {} }
+                if (t !== 'paper' && t !== 'dark') {
+                    t = (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) ? 'dark' : 'paper';
+                }
+                if (t === 'dark') document.documentElement.setAttribute('data-theme', 'dark');
                 var f = localStorage.getItem('appTypography');
-                if (t === 'dark' || t === 'light') document.documentElement.setAttribute('data-theme', t);
-                if (f === 'modern' || f === 'system') document.documentElement.setAttribute('data-typography', f);
+                if (f === 'modern' || f === 'editorial') { f = null; try { localStorage.removeItem('appTypography'); } catch (e) {} }
+                if (f === 'system') document.documentElement.setAttribute('data-typography', 'system');
             } catch (e) {}
         })();
     </script>
@@ -59,91 +65,7 @@
             100% { transform: scale(1); opacity: 1; }
         }
 
-        :root {
-            /* Warm earthy palette — Clay & Sand */
-            --bg: #F3ECE0;
-            --bg-2: #EAE0CE;
-            --card: #FBF6EC;
-            --ink: #26201A;
-            --ink-2: #5A4E3F;
-            --ink-3: #8A7A65;
-            --line: #DDD0B8;
-            --line-2: #C9B99C;
-            --primary: #B8593A;
-            --primary-soft: #E8BFAB;
-            --accent-1: #7A8450;
-            --accent-2: #C89A3E;
-            --positive: #6B8248;
-            --negative: #B8593A;
-
-            --serif: "Instrument Serif", "Iowan Old Style", Georgia, serif;
-            --sans: "Geist", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-            --mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
-
-            /* Backwards-compatible aliases */
-            --font-display: var(--serif);
-            --font-body: var(--sans);
-
-            --color-bg-deep: var(--bg-2);
-            --color-bg-base: var(--bg);
-            --color-bg-elevated: var(--card);
-            --color-bg-surface: var(--bg-2);
-
-            --color-accent-primary: var(--primary);
-            --color-accent-secondary: var(--accent-2);
-            --color-accent-tertiary: var(--accent-1);
-
-            --color-success: var(--positive);
-            --color-success-muted: color-mix(in oklab, var(--positive) 18%, var(--card));
-            --color-danger: var(--negative);
-            --color-danger-muted: color-mix(in oklab, var(--negative) 18%, var(--card));
-
-            --color-text-primary: var(--ink);
-            --color-text-secondary: var(--ink-2);
-            --color-text-muted: var(--ink-3);
-
-            --color-border: var(--line);
-
-            --shadow-lg: 0 16px 48px rgba(38, 32, 26, 0.12);
-
-            --radius-md: 10px;
-            --radius-lg: 14px;
-            --radius-xl: 18px;
-
-            --transition-fast: 0.15s ease;
-            --transition-base: 0.25s ease;
-        }
-
-        /* Theme + typography overrides — kept in sync with index.html */
-        html[data-theme="dark"] {
-            --bg: #1A1612; --bg-2: #221C16; --card: #2A231C;
-            --ink: #F0E6D6; --ink-2: #C9B99C; --ink-3: #8A7A65;
-            --line: #3A302A; --line-2: #4A3F36;
-            --primary: #D67A5C; --primary-soft: #5A2E20;
-            --accent-1: #9CA868; --accent-2: #D9B05A;
-            --positive: #8FA866; --negative: #D67A5C;
-            --chip: #3A302A; --ring: rgba(214, 122, 92, 0.28);
-            --shadow-lg: 0 16px 48px rgba(0, 0, 0, 0.55);
-        }
-        html[data-theme="light"] {
-            --bg: #FFFFFF; --bg-2: #F5F5F5; --card: #FAFAFA;
-            --ink: #1A1A1A; --ink-2: #4A4A4A; --ink-3: #888888;
-            --line: #E5E5E5; --line-2: #D0D0D0;
-            --primary: #2563EB; --primary-soft: #BFDBFE;
-            --accent-1: #059669; --accent-2: #D97706;
-            --positive: #059669; --negative: #DC2626;
-            --chip: #F0F0F0; --ring: rgba(37, 99, 235, 0.18);
-            --shadow-lg: 0 16px 48px rgba(0, 0, 0, 0.10);
-        }
-        html[data-typography="modern"] {
-            --serif: "Inter", ui-sans-serif, system-ui, sans-serif;
-            --sans: "Inter", ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-        }
-        html[data-typography="system"] {
-            --serif: ui-serif, Georgia, "Iowan Old Style", serif;
-            --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
-            --mono: ui-monospace, SFMono-Regular, Menlo, monospace;
-        }
+        /* Design tokens live in /css/theme.css — shared by every page. */
 
         * {
             box-sizing: border-box;

--- a/register.html
+++ b/register.html
@@ -4,6 +4,8 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <title>Register - Asset Manager</title>
+    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ccircle cx='50' cy='50' r='44' fill='%230F6B4F'/%3E%3Crect x='30' y='46' width='40' height='8' rx='2' fill='%23fff'/%3E%3C/svg%3E">
+    <meta name="theme-color" content="#F6F6F4">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400..700&family=Geist:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">

--- a/register.html
+++ b/register.html
@@ -49,16 +49,6 @@
             100% { transform: rotate(360deg); }
         }
 
-        @keyframes float {
-            0%, 100% { transform: translateY(0) rotate(0deg); }
-            50% { transform: translateY(-20px) rotate(5deg); }
-        }
-
-        @keyframes pulse-glow {
-            0%, 100% { box-shadow: 0 0 60px color-mix(in oklab, var(--primary) 20%, transparent); }
-            50% { box-shadow: 0 0 100px color-mix(in oklab, var(--primary) 35%, transparent); }
-        }
-
         @keyframes checkmark {
             0% { transform: scale(0); opacity: 0; }
             50% { transform: scale(1.2); }
@@ -90,51 +80,19 @@
             overflow-y: auto;
         }
 
-        /* Noise texture overlay */
-        body::before {
-            content: '';
-            position: fixed;
-            inset: 0;
-            background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
-            opacity: 0.03;
-            pointer-events: none;
-            z-index: 1000;
-        }
-
-        /* Ambient background orbs */
+        /* Single ambient accent — a soft evergreen radial behind the card */
         .orb {
             position: fixed;
             border-radius: 50%;
-            filter: blur(80px);
+            filter: blur(90px);
             pointer-events: none;
             z-index: 0;
-        }
-
-        .orb-1 {
             width: 500px;
             height: 500px;
-            background: radial-gradient(circle, rgba(16, 185, 129, 0.12) 0%, transparent 70%);
+            background: radial-gradient(circle, var(--primary-soft) 0%, transparent 70%);
             top: -150px;
-            left: -100px;
-            animation: float 15s ease-in-out infinite;
-        }
-
-        .orb-2 {
-            width: 400px;
-            height: 400px;
-            background: radial-gradient(circle, color-mix(in oklab, var(--primary) 10%, transparent) 0%, transparent 70%);
-            bottom: -100px;
             right: -100px;
-            animation: float 18s ease-in-out infinite reverse;
-        }
-
-        .orb-3 {
-            width: 300px;
-            height: 300px;
-            background: radial-gradient(circle, rgba(139, 92, 246, 0.08) 0%, transparent 70%);
-            top: 60%;
-            left: 30%;
-            animation: float 12s ease-in-out infinite;
+            opacity: 0.55;
         }
 
         .container {
@@ -147,35 +105,36 @@
         }
 
         .app-title {
-            font-family: var(--font-display);
+            font-family: var(--display);
             font-size: 2.5rem;
             font-weight: 700;
-            color: var(--color-accent-primary);
+            color: var(--ink);
             text-align: center;
             margin-bottom: 2rem;
-            letter-spacing: -0.03em;
+            letter-spacing: -0.02em;
         }
 
         .register-form {
-            background: var(--color-bg-elevated);
+            background: var(--card);
             padding: 3rem 2.5rem;
             border-radius: var(--radius-xl);
             box-shadow: var(--shadow-lg);
-            border: 1px solid var(--color-border);
+            border: 1px solid var(--line);
             text-align: center;
-            animation: fadeInUp 0.8s ease backwards, pulse-glow 4s ease-in-out infinite;
+            animation: fadeInUp 0.8s ease backwards;
             position: relative;
             overflow: hidden;
         }
 
+        /* Ledger tick — same motif as the dashboard section headings */
         .register-form::before {
             content: '';
             position: absolute;
             top: 0;
-            left: 0;
-            right: 0;
-            height: 4px;
-            background: linear-gradient(90deg, var(--color-success) 0%, var(--color-accent-primary) 50%, var(--color-accent-secondary) 100%);
+            left: 2.5rem;
+            width: 24px;
+            height: 2px;
+            background: var(--primary);
         }
 
         .register-form h2 {
@@ -241,27 +200,25 @@
         button {
             width: 100%;
             padding: 1.1rem;
-            background: linear-gradient(135deg, var(--color-accent-primary) 0%, var(--color-accent-tertiary) 100%);
-            color: var(--color-bg-deep);
+            background: var(--primary);
+            color: #fff;
             border: none;
             border-radius: var(--radius-md);
             font-size: 0.9rem;
-            font-family: var(--font-body);
-            font-weight: 700;
+            font-family: var(--sans);
+            font-weight: 600;
             cursor: pointer;
-            transition: all var(--transition-base);
+            transition: background var(--transition-base), box-shadow var(--transition-base), transform var(--transition-base);
             margin-top: 0.5rem;
-            text-transform: uppercase;
-            letter-spacing: 0.08em;
-            box-shadow: 0 4px 24px color-mix(in oklab, var(--primary) 30%, transparent);
+            letter-spacing: 0.02em;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
         }
 
         button:hover {
-            transform: translateY(-2px);
-            box-shadow: 0 8px 32px color-mix(in oklab, var(--primary) 40%, transparent);
+            background: color-mix(in oklab, var(--primary) 88%, black);
+            box-shadow: 0 4px 16px var(--ring);
         }
 
         button:active {
@@ -272,7 +229,7 @@
             margin-top: 1.5rem;
             padding: 1rem 1.25rem;
             background: var(--color-danger-muted);
-            border: 1px solid rgba(239, 68, 68, 0.3);
+            border: 1px solid color-mix(in oklab, var(--negative) 35%, var(--card));
             border-radius: var(--radius-md);
             color: var(--color-danger);
             font-size: 0.875rem;
@@ -289,7 +246,7 @@
             margin-top: 1.5rem;
             padding: 1.25rem;
             background: var(--color-success-muted);
-            border: 1px solid rgba(16, 185, 129, 0.3);
+            border: 1px solid color-mix(in oklab, var(--positive) 35%, var(--card));
             border-radius: var(--radius-md);
             color: var(--color-success);
             font-size: 0.875rem;
@@ -343,8 +300,8 @@
             left: 50%;
             margin-top: -10px;
             margin-left: -10px;
-            border: 2.5px solid rgba(255, 255, 255, 0.3);
-            border-top: 2.5px solid var(--color-text-primary);
+            border: 2.5px solid rgba(255, 255, 255, 0.35);
+            border-top: 2.5px solid #fff;
             border-radius: 50%;
             animation: spin 0.6s linear infinite;
         }
@@ -404,7 +361,7 @@
         }
 
         .password-strength-bar.weak { width: 33%; background: var(--color-danger); }
-        .password-strength-bar.medium { width: 66%; background: var(--color-accent-primary); }
+        .password-strength-bar.medium { width: 66%; background: var(--warning); }
         .password-strength-bar.strong { width: 100%; background: var(--color-success); }
 
         /* PayPal Purchase Section */
@@ -478,7 +435,7 @@
             margin-top: 1rem;
             padding: 1rem;
             background: var(--color-success-muted);
-            border: 1px solid rgba(16, 185, 129, 0.3);
+            border: 1px solid color-mix(in oklab, var(--positive) 35%, var(--card));
             border-radius: var(--radius-md);
             color: var(--color-success);
             font-size: 0.85rem;
@@ -519,7 +476,7 @@
             margin-top: 1rem;
             padding: 1rem;
             background: var(--color-danger-muted);
-            border: 1px solid rgba(239, 68, 68, 0.3);
+            border: 1px solid color-mix(in oklab, var(--negative) 35%, var(--card));
             border-radius: var(--radius-md);
             color: var(--color-danger);
             font-size: 0.85rem;
@@ -532,7 +489,7 @@
 
         .lang-toggle {
             position: fixed;
-            bottom: 1.25rem;
+            bottom: calc(1.25rem + env(safe-area-inset-bottom, 0px));
             right: 1.25rem;
             z-index: 999;
             width: 2.5rem;
@@ -582,18 +539,12 @@
             .app-title {
                 font-size: 2rem;
             }
-
-            .orb-1, .orb-2 {
-                opacity: 0.5;
-            }
         }
     </style>
 </head>
 <body>
     <button class="lang-toggle" data-i18n-title="lang.switch.title" onclick="setLang(getLang()==='en'?'pt':'en')" aria-label="Toggle language">🌐</button>
-    <div class="orb orb-1"></div>
-    <div class="orb orb-2"></div>
-    <div class="orb orb-3"></div>
+    <div class="orb" aria-hidden="true"></div>
 
     <div class="container">
         <h1 class="app-title" data-i18n="common.appName">Asset Manager</h1>

--- a/register.html
+++ b/register.html
@@ -203,7 +203,7 @@
             width: 100%;
             padding: 1.1rem;
             background: var(--primary);
-            color: #fff;
+            color: var(--on-primary);
             border: none;
             border-radius: var(--radius-md);
             font-size: 0.9rem;

--- a/server.js
+++ b/server.js
@@ -958,12 +958,18 @@ Object.entries(htmlPages).forEach(([route, file]) => {
     });
 });
 
-// Only the /js directory is served statically. Every HTML page is rendered
-// through an explicit route above (htmlPages), and there are no other
-// browser-served assets at the project root. Mounting express.static at
-// __dirname previously exposed server.js, config.js, db/*, package*.json
+// Only the /js and /css directories are served statically. Every HTML page
+// is rendered through an explicit route above (htmlPages), and there are no
+// other browser-served assets at the project root. Mounting express.static
+// at __dirname previously exposed server.js, config.js, db/*, package*.json
 // and node_modules/** to anonymous GET requests (CodeQL alert #5).
 app.use('/js', express.static(path.join(__dirname, 'js'), {
+    maxAge: '1h',
+    dotfiles: 'deny',
+    index: false,
+    redirect: false
+}));
+app.use('/css', express.static(path.join(__dirname, 'css'), {
     maxAge: '1h',
     dotfiles: 'deny',
     index: false,


### PR DESCRIPTION
## Summary

Full frontend redesign replacing the earthy "Clay & Sand" theme with **"Ledger"** — a modern financial-instrument identity — plus an analytics consolidation and an accessibility floor. Net diff is negative (~1,050 insertions / ~1,400 deletions): the app got smaller.

### New identity
- **Paper** (porcelain light, new default) and **Graphite** (dark) themes with one evergreen accent; the earthy theme is retired.
- Signature move: the sidebar/topbar chrome stays graphite in **both** themes via theme-invariant `--chrome-*` tokens — only the content canvas flips.
- Typography: Bricolage Grotesque (display) / Geist (body + all money figures, with `tabular-nums` and dimmed decimals) / JetBrains Mono (micro-labels, kept). Instrument Serif and Inter dropped from the font payload.
- Decorative gradients and per-card color stripes replaced by a single "ledger tick" motif.

### One token source instead of four
- New **`css/theme.css`** holds every design token, shared by all four HTML pages (ends the hand-duplicated `:root` blocks). Served via a new `/css` static mount; `injectCacheBust` already covers `<link>` hrefs.
- Theme migration in the per-page bootstrap: stored `light` → `paper` (persisted once); no stored key now follows `prefers-color-scheme`; legacy typography presets cleared (`default | system` remain).

### Analytics rethink
- Removed the legacy 3-stat summary bar (it duplicated the hero KPIs — net worth was displayed 4×).
- The two category charts merged into one panel with a **Bar / Doughnut / Trend** toggle (persisted; the stacked view's hardcoded slate tooltip is fixed to theme tokens).
- New **Budget status panel** in the freed grid slot: current-month overall + top-6 budgeted categories with progress bars and over-budget pills, reusing the Budgets modal data + helpers; refreshes when the modal closes.
- Net-worth line restyled (2px, subtle fill, last-point-only marker); cash-flow bars on the semantic positive/negative palette with matching average-line annotations — now user-toggleable via an **Avg** switch (persisted).
- New **All Categories** filter button beside Clear Filters for all-except-a-few filtering.
- Entry tag chips are theme-neutral (chip + per-category color dot) instead of 17 hardcoded Tailwind-tinted `.tag-*` rules; hidden legacy `#categoryFilter` select and its sync machinery removed.

### Chat + auth pages
- Chat widget fully retokenized off its stale amber/indigo palette; FAB gains `aria-expanded`/`aria-controls`.
- Login hero sits on the graphite chrome with the feature grid trimmed 10 → 4; register/forgot lose the noise overlay and off-palette orbs; PayPal section rethemed (no flow changes).

### Accessibility floor
- Global `:focus-visible` outlines (chrome-scoped variant on graphite), `prefers-reduced-motion` support, skip-to-content link, mobile drawer scroll lock, inline-SVG favicon + `theme-color` on all pages, AA-verified contrast for the small mono labels (`--ink-3` adjusted in both themes), `--on-primary` token so button text stays readable on the bright dark-theme primary.

### Docs
- CLAUDE.md updated (theme model, chart layout, `/css` mount, the `htmlCache` restart-on-HTML-edit note, and the hidden action-bus warning).

## Verification

Drove the app end-to-end with headless Chrome against a seeded local Postgres:
- Login → dashboard in both themes (screenshots reviewed); charts, sparklines, budget panel states (ok / ≥70% warning / over-budget) all render on-theme.
- Category toggle Bar/Doughnut/Trend with reload persistence; Avg toggle hides/shows annotations and persists; All Categories selects 17/17 chips and survives reload.
- Chat open/close flips `aria-expanded`; localStorage migrations (`light`→`paper`, `modern` cleared) exercised.
- `node --check` on all touched JS; zero-grep sweeps for the removed palette/plumbing.

Not exercised: couple/partner view with a linked pair, PayPal purchase flow (retheme only), PT-BR at 480px width (short keys chosen; worth a quick manual look).

🤖 Generated with [Claude Code](https://claude.com/claude-code)